### PR TITLE
fix(parser): circuit breaker caps tool calls at 25 per response

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -5,7 +5,7 @@ import { createQwenStream } from '../services/qwen.ts';
 import { OpenAIRequest, Message } from '../utils/types.ts';
 import type { FunctionToolDefinition } from '../tools/types.ts';
 import { robustParseJSON } from '../utils/json.ts';
-import { StreamingToolParser } from '../tools/parser.ts';
+import { StreamingToolParser, MAX_TOOL_CALLS_PER_RESPONSE } from '../tools/parser.ts';
 import { validateSingleToolCall } from '../tools/guard.ts';
 import { filterContent, stripToolCallArtifacts } from '../utils/contentFilter.ts';
 import { sessionPool } from '../services/sessionPool.ts';
@@ -435,6 +435,7 @@ export async function chatCompletions(c: Context) {
       if (!cleanOutput) toolParser.skipPreProcess = true;
       const toolCallsOut: any[] = [];
       const correctionPrompts: string[] = []; // Guard rejection messages for logging
+      let toolCallLimitReached = false;
 
       let buffer = '';
       let completionTokens = 0;
@@ -442,6 +443,9 @@ export async function chatCompletions(c: Context) {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
+
+        // Circuit breaker: if tool call limit hit, stop consuming upstream
+        if (toolCallLimitReached) break;
 
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split('\n');
@@ -566,12 +570,28 @@ export async function chatCompletions(c: Context) {
                     logDebug('PARSED TOOL CALL', { name: tc.name, arguments: tc.arguments });
                   }
                 }
+
+                // Circuit breaker: check if parser hit the tool call limit
+                if (toolParser.getEmittedToolCallCount() >= MAX_TOOL_CALLS_PER_RESPONSE) {
+                  console.error(
+                    `[Chat][TOOL CALL LIMIT] Non-streaming: ${toolParser.getEmittedToolCallCount()} tool calls emitted, ` +
+                    `stopping consumption. account=${resolvedEmail} model=${body.model}`
+                  );
+                  logStore.updateEntry(logId, entry => {
+                    entry.errors.push(`Tool call limit reached (${MAX_TOOL_CALLS_PER_RESPONSE}). Stopped consumption.`);
+                  });
+                  toolCallLimitReached = true;
+                  break;
+                }
               }
             }
           } catch (e) {
             console.debug('[Chat] Non-streaming: parse error on chunk, ignoring partial:', (e as Error)?.message);
           }
         }
+
+        // Break outer while(true) if limit hit inside for-loop
+        if (toolCallLimitReached) break;
       }
 
       const upstreamError = parseQwenErrorPayload(buffer);
@@ -740,6 +760,7 @@ export async function chatCompletions(c: Context) {
       const toolParser = new StreamingToolParser();
       if (!toolCalling) toolParser.passThrough = true;
       if (!cleanOutput) toolParser.skipPreProcess = true;
+      let toolCallLimitReached = false;
 
       let buffer = '';
       let completionTokens = 0;
@@ -755,6 +776,8 @@ export async function chatCompletions(c: Context) {
       while (true) {
         if (streamDone) break;
         if (c.req.raw?.signal?.aborted) { reader.cancel(); break; }
+        // Circuit breaker: stop consuming upstream if tool call limit hit
+        if (toolCallLimitReached) { reader.cancel(); break; }
 
         let done: boolean;
         let value: Uint8Array | undefined;
@@ -1045,6 +1068,28 @@ export async function chatCompletions(c: Context) {
                   });
                 }
 
+                // Circuit breaker: check if parser hit the tool call limit
+                if (!toolCallLimitReached && toolParser.getEmittedToolCallCount() >= MAX_TOOL_CALLS_PER_RESPONSE) {
+                  console.error(
+                    `[Chat][TOOL CALL LIMIT] Streaming: ${toolParser.getEmittedToolCallCount()} tool calls emitted, ` +
+                    `stopping consumption. account=${resolvedEmail} model=${body.model}`
+                  );
+                  logStore.updateEntry(logId, entry => {
+                    entry.errors.push(`Tool call limit reached (${MAX_TOOL_CALLS_PER_RESPONSE}). Stopped stream consumption.`);
+                  });
+                  toolCallLimitReached = true;
+                  // Emit a text message informing the client that the limit was hit
+                  await writeEvent({
+                    id: completionId,
+                    object: 'chat.completion.chunk',
+                    created: Math.floor(Date.now() / 1000),
+                    model: body.model,
+                    choices: [makeChoice({
+                      content: `\n\n[Tool call limit reached: ${MAX_TOOL_CALLS_PER_RESPONSE} tool calls emitted. Response truncated to prevent runaway output.]`
+                    })]
+                  });
+                }
+
                 // Only send text if all tool calls passed guard validation.
                 // If any failed, suppress the text to prevent polluting client context.
                 if (pendingText && allToolCallsValid && cleanedText) {
@@ -1230,7 +1275,9 @@ export async function chatCompletions(c: Context) {
         prompt_tokens_details: { cached_tokens: 0 }
       };
   
-      const finalFinishReason = toolParser.getEmittedToolCallCount() > 0 ? 'tool_calls' : 'stop';
+      const finalFinishReason = toolCallLimitReached
+        ? 'stop'  // Limit hit: treat as stop, not tool_calls (prevents client re-invoking)
+        : toolParser.getEmittedToolCallCount() > 0 ? 'tool_calls' : 'stop';
   
       await writeEvent({
         id: completionId,

--- a/src/tools/parser.ts
+++ b/src/tools/parser.ts
@@ -32,6 +32,14 @@ const MAX_BUFFER_SIZE = 65536;
 const TRIM_KEEP_CONTEXT = 4096;
 /** Maximum search distance backward from "name" to find opening brace */
 const MAX_BRACE_SEARCH_DISTANCE = 500;
+/**
+ * Circuit breaker: maximum tool calls extracted per response.
+ * If the model vomits 30+ recursive tool calls (see output-problems/07.md),
+ * we stop extracting and treat the rest as plain text. This prevents the
+ * client from being flooded with tool_call events and the model from entering
+ * an infinite self-referential loop.
+ */
+export const MAX_TOOL_CALLS_PER_RESPONSE = 25;
 
 export class StreamingToolParser {
   private buffer = '';
@@ -67,6 +75,18 @@ export class StreamingToolParser {
     let offset = 0;
 
     while (offset < this.buffer.length) {
+      // ── Circuit breaker: stop extracting tool calls after limit ─────────
+      // When the model generates dozens of recursive tool calls (e.g., reading
+      // its own source files in a loop), we halt extraction and emit the
+      // remainder as plain text. This prevents infinite tool emission.
+      if (this.emittedCount >= MAX_TOOL_CALLS_PER_RESPONSE) {
+        if (this.textEmissionBoundary < this.buffer.length) {
+          result.text += this.buffer.substring(this.textEmissionBoundary);
+          this.textEmissionBoundary = this.buffer.length;
+        }
+        break;
+      }
+
       // ── Handle <think> / <thinking> blocks ─────────────────────────────
       const thinkResult = this.extractThinkBlock(offset);
       if (thinkResult) {
@@ -115,8 +135,21 @@ export class StreamingToolParser {
       if (isArray) {
         const arrayResult = this.extractArrayToolCalls(jsonStart);
         if (arrayResult) {
-          result.toolCalls.push(...arrayResult.toolCalls);
-          this.emittedCount += arrayResult.toolCalls.length;
+          // Circuit breaker: cap array extraction at remaining budget
+          const budget = MAX_TOOL_CALLS_PER_RESPONSE - this.emittedCount;
+          if (budget <= 0) {
+            // Over limit — emit as text
+            if (this.textEmissionBoundary < this.buffer.length) {
+              result.text += this.buffer.substring(this.textEmissionBoundary);
+              this.textEmissionBoundary = this.buffer.length;
+            }
+            break;
+          }
+          const extracted = arrayResult.toolCalls.slice(0, budget);
+          result.toolCalls.push(...extracted);
+          this.emittedCount += extracted.length;
+          // If array had more than budget, we still advance past the whole array
+          // but only emit up to budget tool calls
           offset = arrayResult.endOffset;
           this.textEmissionBoundary = offset;
           continue;
@@ -397,6 +430,13 @@ export class StreamingToolParser {
 
       // Try one final pass to extract tool calls from remaining buffer
       while (true) {
+        // Circuit breaker: stop extracting if at limit
+        if (this.emittedCount >= MAX_TOOL_CALLS_PER_RESPONSE) {
+          result.text += remaining;
+          remaining = '';
+          break;
+        }
+
         const braceIdx = remaining.indexOf('{');
         if (braceIdx === -1) break;
 


### PR DESCRIPTION
## Problem\n\nSpecific inputs cause the model to generate 30-50+ recursive tool calls (read/grep targeting its own codebase files), producing massive output and wasting resources. See `output-problems/07.md` for reproduction.\n\n## Fix\n\n- **parser.ts**: `MAX_TOOL_CALLS_PER_RESPONSE = 25` cap enforced in `extract()`, array extraction, and `flush()`\n- **chat.ts**: Both streaming and non-streaming paths break early on limit\n- Streaming path forces `finish_reason='stop'` to prevent OpenAI-compatible clients from auto-re-invoking tools\n- Truncation notice emitted so client knows output was cut\n\n## Verification\n\n- `tsc --noEmit` clean\n- `npm test` 34/34 pass\n- +102/-7 lines across parser.ts and chat.ts