### PR TITLE
fix: improve tool calls and account failover

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -4,7 +4,6 @@ import { OpenAIRequest } from "../utils/types.ts";
 import { config } from "../services/configService.ts";
 import { logStore } from "../services/logStore.ts";
 import { modelRouter } from "../services/modelRouter.ts";
-import { pickAccount } from "../services/auth.ts";
 import { checkContextWindow, estimateTokens } from "../utils/tokenEstimator.ts";
 import { handleStreamingRequest } from "./chatStreaming.ts";
 import { handleNonStreamingRequest } from "./chatNonStreaming.ts";
@@ -106,11 +105,8 @@ export async function chatCompletions(c: Context) {
 
     const isThinkingModel = !body.model.includes("no-thinking");
 
-    const selectedAccount = pickAccount();
-    const accountEmail = selectedAccount?.email;
-
     let sessionResult = await acquireSessionWithCorrections(
-      accountEmail,
+      undefined,
       systemPrompt,
       prompt,
     );

--- a/src/routes/chatHelpers.ts
+++ b/src/routes/chatHelpers.ts
@@ -793,6 +793,7 @@ export function buildPromptAndSystem(
     const toolsJson = JSON.stringify(formattedTools, null, 2);
 
     systemPrompt += `\n\n# TOOLS AVAILABLE\nYou have access to:\n${toolsJson}\n\n`;
+    systemPrompt += `Do NOT use Qwen native tools, XML tags, markdown fences, or function-call wrappers. To call a tool, output exactly one plain JSON object and no surrounding text. Format: {"name":"tool_name","arguments":{"param":"value"}}. Example: {"name":"get_weather","arguments":{"city":"Paris"}}\n\n`;
 
     if (body.tool_choice === "required" || body.tool_choice === "any") {
       systemPrompt += `CRITICAL: Call tools to gather the information you need. After receiving each tool result, READ and ANALYZE it carefully. If the results give you enough information to answer the user, respond directly — do NOT continue calling tools unnecessarily. Only call additional tools if you genuinely need more data. NEVER call the same tool repeatedly with the same arguments.\n\n`;

--- a/src/routes/toolPrompt.test.ts
+++ b/src/routes/toolPrompt.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { buildPromptAndSystem } from './chatHelpers.ts';
+
+test('tool prompt forbids Qwen native tool calls and requires gateway JSON only', () => {
+  const { systemPrompt } = buildPromptAndSystem(
+    [{ role: 'user', content: 'Weather in Paris?' }],
+    {
+      model: 'qwen3.7-max-no-thinking',
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            description: 'Get weather',
+            parameters: {
+              type: 'object',
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+            },
+          },
+        },
+      ],
+    },
+    4096,
+    true,
+  );
+
+  assert.match(systemPrompt, /Do NOT use Qwen native tools/i);
+  assert.match(systemPrompt, /plain JSON object/i);
+  assert.match(systemPrompt, /\{"name":"get_weather","arguments":\{"city":"Paris"\}\}/);
+});

--- a/src/services/auth.test.ts
+++ b/src/services/auth.test.ts
@@ -1,6 +1,8 @@
 import { test, describe, before, after } from 'node:test';
 import assert from 'node:assert';
 import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
 import path from 'path';
 import crypto from 'crypto';
 
@@ -17,6 +19,8 @@ import {
 } from './auth';
 
 const TEST_COOKIE_DIR = 'qwen_profile/cookies';
+const ORIGINAL_CWD = process.cwd();
+const TEST_CWD = mkdtempSync(path.join(tmpdir(), 'qwen-gate-auth-test-'));
 
 function hashEmail(email: string): string {
   return crypto.createHash('md5').update(email.toLowerCase().trim()).digest('hex');
@@ -59,6 +63,7 @@ describe('account inFlight and totalRequests tracking', () => {
 
 describe('hot-reload: reloadAccounts()', () => {
   before(() => {
+    process.chdir(TEST_CWD);
     cleanupTestCookies();
     clearAuth();
   });
@@ -66,6 +71,8 @@ describe('hot-reload: reloadAccounts()', () => {
   after(() => {
     cleanupTestCookies();
     clearAuth();
+    process.chdir(ORIGINAL_CWD);
+    rmSync(TEST_CWD, { recursive: true, force: true });
   });
 
   test('S1: detects new account file added after init', async () => {

--- a/src/services/sessionPool.test.ts
+++ b/src/services/sessionPool.test.ts
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatQwenEnvelopeError } from './sessionPool.ts';
+
+test('formatQwenEnvelopeError includes upstream code and details', () => {
+  const message = formatQwenEnvelopeError({
+    success: false,
+    data: {
+      code: 'Bad_Request',
+      details: 'Your account is currently pending activation.',
+    },
+  });
+
+  assert.match(message, /Bad_Request/);
+  assert.match(message, /pending activation/);
+});

--- a/src/services/sessionPool.ts
+++ b/src/services/sessionPool.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { getBasicHeaders } from './playwright.ts';
-import { pickAccount, incrementInFlight, decrementInFlight, incrementTotalRequests, getAccountByEmail } from './auth.ts';
+import { pickAccount, incrementInFlight, decrementInFlight, incrementTotalRequests, getAccountByEmail, throttleAccount, getAllAccountEmails } from './auth.ts';
 import { createNetworkEntry, recordResponse, completeEntry, errorEntry } from './networkDebug.ts';
 import { logStore } from './logStore.js';
 import { config } from './configService.ts';
@@ -34,6 +34,12 @@ interface WaiterEntry {
   timer: ReturnType<typeof setTimeout>;
 }
 
+export function formatQwenEnvelopeError(json: any): string {
+  const code = json?.data?.code || json?.code || 'unknown';
+  const details = json?.data?.details || json?.details || json?.message || '';
+  return details ? `${code}: ${details}` : String(code);
+}
+
 export class SessionPool {
   private waiting: Array<WaiterEntry> = [];
   private activeSessions = new Set<string>();
@@ -57,36 +63,49 @@ export class SessionPool {
       return { chatId: mockId, parentId: null, inUse: true, accountEmail: 'mock@test' };
     }
 
-    // If no email specified, pick the best account
-    const resolvedEmail = email || pickAccount()?.email;
+    const maxAttempts = email ? 1 : Math.max(1, getAllAccountEmails().length);
+    let lastErr: unknown;
 
-    // Mark account as in-flight before starting async ops (runs synchronously, no race)
-    if (resolvedEmail) {
-      incrementInFlight(resolvedEmail);
-    }
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      // If no email specified, pick the best account after any previous throttling.
+      const resolvedEmail = email || pickAccount()?.email;
 
-    try {
-      const [{ cookie, userAgent, email: actualEmail }, chatId] = await Promise.all([
-        getBasicHeaders(resolvedEmail),
-        this.createSession(resolvedEmail)
-      ]);
-      const entry: PoolEntry = {
-        chatId,
-        parentId: null,
-        inUse: true,
-        cachedHeaders: { cookie, userAgent },
-        accountEmail: actualEmail || resolvedEmail,
-      };
-      this.activeSessions.add(chatId);
-      this.activeCount++;
-      logStore.log('info', 'pool', 'Session acquired' + (entry.accountEmail ? ': ' + entry.accountEmail.split('@')[0] : ''));
-      return entry;
-    } catch (err) {
+      // Mark account as in-flight before starting async ops (runs synchronously, no race)
       if (resolvedEmail) {
-        decrementInFlight(resolvedEmail);
+        incrementInFlight(resolvedEmail);
       }
-      throw err;
+
+      try {
+        const [{ cookie, userAgent, email: actualEmail }, chatId] = await Promise.all([
+          getBasicHeaders(resolvedEmail),
+          this.createSession(resolvedEmail)
+        ]);
+        const entry: PoolEntry = {
+          chatId,
+          parentId: null,
+          inUse: true,
+          cachedHeaders: { cookie, userAgent },
+          accountEmail: actualEmail || resolvedEmail,
+        };
+        this.activeSessions.add(chatId);
+        this.activeCount++;
+        logStore.log('info', 'pool', 'Session acquired' + (entry.accountEmail ? ': ' + entry.accountEmail.split('@')[0] : ''));
+        return entry;
+      } catch (err: any) {
+        lastErr = err;
+        if (resolvedEmail) {
+          decrementInFlight(resolvedEmail);
+          if (!email && /pending activation|Bad_Request|Chats\/new returned no id/i.test(err?.message || '')) {
+            throttleAccount(resolvedEmail, 30 * 60 * 1000);
+            logStore.log('warn', 'pool', `Skipping account ${resolvedEmail}: ${err.message}`);
+            continue;
+          }
+        }
+        throw err;
+      }
     }
+
+    throw lastErr instanceof Error ? lastErr : new Error('Failed to acquire session');
   }
 
   getWaitingCount(): number {
@@ -259,8 +278,9 @@ export class SessionPool {
     }
     const json = await response.json();
     if (!json.data?.id) {
-      errorEntry(debugEntry.id, `Chats/new returned no id`);
-      throw new Error(`Chats/new returned no id: ${JSON.stringify(json).substring(0, 100)}`);
+      const message = formatQwenEnvelopeError(json);
+      errorEntry(debugEntry.id, `Chats/new returned no id: ${message}`);
+      throw new Error(`Chats/new returned no id: ${message}`);
     }
     completeEntry(debugEntry.id);
     return json.data.id;

--- a/src/tools/parser.test.ts
+++ b/src/tools/parser.test.ts
@@ -467,4 +467,53 @@ describe('StreamingToolParser flush leak vector', () => {
     assert.strictEqual(parser.getEmittedToolCallCount(), 1,
       'Streaming final finish_reason depends on emitted count after flush');
   });
+
+  it('S13: Kilo XML function_calls block is extracted as tool call', () => {
+    const parser = new StreamingToolParser();
+    const xml = '<function_calls>\n' +
+      '<invoke name="bash">\n' +
+      '<parameter name="command">cd /home/honi-claw/QuantumTrader/dashboard && npm run build 2>&1 | tail -20</parameter>\n' +
+      '<parameter name="description">Rebuild frontend with fix</parameter>\n' +
+      '<parameter name="timeout">60000</parameter>\n' +
+      '</invoke>\n' +
+      '</function_calls>';
+
+    const result = parser.feed(xml);
+    const flush = parser.flush();
+    const calls = [...result.toolCalls, ...flush.toolCalls];
+    const text = result.text + flush.text;
+
+    assert.strictEqual(calls.length, 1, 'Expected XML invoke to become one tool call');
+    assert.strictEqual(calls[0].name, 'bash');
+    assert.strictEqual(calls[0].arguments.command, 'cd /home/honi-claw/QuantumTrader/dashboard && npm run build 2>&1 | tail -20');
+    assert.strictEqual(calls[0].arguments.description, 'Rebuild frontend with fix');
+    assert.strictEqual(calls[0].arguments.timeout, 60000);
+    assert.ok(!text.includes('<function_calls>'), 'XML tool block leaked into text');
+  });
+
+  it('S14: split Kilo XML function_calls block is buffered until complete', () => {
+    const parser = new StreamingToolParser();
+    const chunks = [
+      '<function_',
+      'calls>\n<invoke name="bash">\n',
+      '<parameter name="command">date</parameter>\n',
+      '</invoke>\n</function_calls>',
+    ];
+
+    const calls: any[] = [];
+    let text = '';
+    for (const chunk of chunks) {
+      const result = parser.feed(chunk);
+      calls.push(...result.toolCalls);
+      text += result.text;
+    }
+    const flush = parser.flush();
+    calls.push(...flush.toolCalls);
+    text += flush.text;
+
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].name, 'bash');
+    assert.strictEqual(calls[0].arguments.command, 'date');
+    assert.ok(!text.includes('<function_'), 'Partial XML tag leaked into text');
+  });
 });

--- a/src/tools/parser.test.ts
+++ b/src/tools/parser.test.ts
@@ -516,4 +516,46 @@ describe('StreamingToolParser flush leak vector', () => {
     assert.strictEqual(calls[0].arguments.command, 'date');
     assert.ok(!text.includes('<function_'), 'Partial XML tag leaked into text');
   });
+
+  it('S15: Kilo ToolRead XML block is extracted as read tool call', () => {
+    const parser = new StreamingToolParser();
+    const xml = '<ToolRead>\n' +
+      '<parameter name="filePath">C:\\Dev\\m3uchecker2\\Views\\PlayerOverlayWindow.xaml</parameter>\n' +
+      '<parameter name="offset">218</parameter>\n' +
+      '<parameter name="limit">50</parameter>\n' +
+      '</ToolRead>';
+
+    const result = parser.feed(xml);
+    const flush = parser.flush();
+    const calls = [...result.toolCalls, ...flush.toolCalls];
+    const text = result.text + flush.text;
+
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].name, 'read');
+    assert.strictEqual(calls[0].arguments.filePath, 'C:\\Dev\\m3uchecker2\\Views\\PlayerOverlayWindow.xaml');
+    assert.strictEqual(calls[0].arguments.offset, 218);
+    assert.strictEqual(calls[0].arguments.limit, 50);
+    assert.ok(!text.includes('<ToolRead>'), 'ToolRead XML leaked into text');
+  });
+
+  it('S16: lowercase XML tool block with param tags is extracted', () => {
+    const parser = new StreamingToolParser();
+    const xml = '<read>\n' +
+      '<param name="filePath">C:\\Dev\\m3uchecker2\\Views\\PlayerOverlayWindow.xaml</param>\n' +
+      '<param name="limit">50</param>\n' +
+      '<param name="offset">218</param>\n' +
+      '</read>';
+
+    const result = parser.feed(xml);
+    const flush = parser.flush();
+    const calls = [...result.toolCalls, ...flush.toolCalls];
+    const text = result.text + flush.text;
+
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(calls[0].name, 'read');
+    assert.strictEqual(calls[0].arguments.filePath, 'C:\\Dev\\m3uchecker2\\Views\\PlayerOverlayWindow.xaml');
+    assert.strictEqual(calls[0].arguments.limit, 50);
+    assert.strictEqual(calls[0].arguments.offset, 218);
+    assert.ok(!text.includes('<read>'), 'lowercase XML tool block leaked into text');
+  });
 });

--- a/src/tools/parser.test.ts
+++ b/src/tools/parser.test.ts
@@ -454,4 +454,17 @@ describe('StreamingToolParser flush leak vector', () => {
     assert.ok(!allText.includes('"description"'),
       `JSON key 'description' leaked as text: ${JSON.stringify(allText)}`);
   });
+
+  it('S12: emitted tool-call count survives flush for streaming finish_reason', () => {
+    const parser = new StreamingToolParser();
+    const result = parser.feed('{"name": "bash", "arguments": {"command": "date"}}');
+
+    assert.strictEqual(result.toolCalls.length, 1);
+    assert.strictEqual(parser.getEmittedToolCallCount(), 1);
+
+    parser.flush();
+
+    assert.strictEqual(parser.getEmittedToolCallCount(), 1,
+      'Streaming final finish_reason depends on emitted count after flush');
+  });
 });

--- a/src/tools/parser.ts
+++ b/src/tools/parser.ts
@@ -158,7 +158,6 @@ export class StreamingToolParser {
       result.text += remaining;
     }
     this.buffer = '';
-    this.emittedCount = 0;
     this.textEmissionBoundary = 0;
     return result;
   }

--- a/src/tools/parser.ts
+++ b/src/tools/parser.ts
@@ -27,12 +27,34 @@ export class StreamingToolParser {
     while (offset < this.buffer.length) {
       const nextBraceQuote = this.buffer.indexOf('{"', offset);
       const nextBraceBracket = this.buffer.indexOf('[{', offset);
+      const nextFunctionCalls = this.buffer.indexOf('<function_calls>', offset);
       let jsonStart = -1;
       let isArray = false;
       if (nextBraceQuote !== -1 && (nextBraceBracket === -1 || nextBraceQuote <= nextBraceBracket)) {
         jsonStart = nextBraceQuote;
       } else if (nextBraceBracket !== -1) { jsonStart = nextBraceBracket; isArray = true; }
+      if (nextFunctionCalls !== -1 && (jsonStart === -1 || nextFunctionCalls < jsonStart)) {
+        if (this.textEmissionBoundary < nextFunctionCalls) {
+          result.text += this.buffer.substring(this.textEmissionBoundary, nextFunctionCalls);
+          this.textEmissionBoundary = nextFunctionCalls;
+        }
+        const xmlResult = this.extractXmlToolCalls(nextFunctionCalls);
+        if (!xmlResult) { break; }
+        result.toolCalls.push(...xmlResult.toolCalls);
+        this.emittedCount += xmlResult.toolCalls.length;
+        offset = xmlResult.endOffset;
+        this.textEmissionBoundary = offset;
+        continue;
+      }
       if (jsonStart === -1) {
+        const partialXmlStart = this.findPartialXmlStart();
+        if (partialXmlStart !== -1) {
+          if (this.textEmissionBoundary < partialXmlStart) {
+            result.text += this.buffer.substring(this.textEmissionBoundary, partialXmlStart);
+            this.textEmissionBoundary = partialXmlStart;
+          }
+          break;
+        }
         if (this.textEmissionBoundary < this.buffer.length) {
           result.text += this.buffer.substring(this.textEmissionBoundary);
           this.textEmissionBoundary = this.buffer.length;
@@ -102,6 +124,49 @@ export class StreamingToolParser {
       if (toolCalls.length > 0) return { toolCalls, endOffset: startIdx + arrayEnd };
     } catch { /* Array parse failed */ }
     return null;
+  }
+  private extractXmlToolCalls(startIdx: number): { toolCalls: ParsedToolCall[]; endOffset: number } | null {
+    const closeTag = '</function_calls>';
+    const endIdx = this.buffer.indexOf(closeTag, startIdx);
+    if (endIdx === -1) return null;
+    const endOffset = endIdx + closeTag.length;
+    const block = this.buffer.substring(startIdx, endOffset);
+    const toolCalls: ParsedToolCall[] = [];
+    const invokeRe = /<invoke\s+name="([^"]+)"\s*>([\s\S]*?)<\/invoke>/g;
+    let match: RegExpExecArray | null;
+    while ((match = invokeRe.exec(block))) {
+      const name = match[1].trim();
+      if (!name) continue;
+      const args: Record<string, unknown> = {};
+      const params = match[2];
+      const paramRe = /<parameter\s+name="([^"]+)"\s*>([\s\S]*?)<\/parameter>/g;
+      let param: RegExpExecArray | null;
+      while ((param = paramRe.exec(params))) {
+        const key = param[1].trim();
+        if (!key) continue;
+        const rawValue = this.decodeXml(param[2].trim());
+        args[key] = /^-?\d+(?:\.\d+)?$/.test(rawValue) ? Number(rawValue) : rawValue;
+      }
+      toolCalls.push({ id: `call_${crypto.randomUUID()}`, name, arguments: args });
+    }
+    return { toolCalls, endOffset };
+  }
+  private decodeXml(text: string): string {
+    return text
+      .replace(/&quot;/g, '"')
+      .replace(/&apos;/g, "'")
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&');
+  }
+  private findPartialXmlStart(): number {
+    const tag = '<function_calls>';
+    const max = Math.min(tag.length - 1, this.buffer.length);
+    for (let len = max; len > 0; len--) {
+      const suffix = this.buffer.substring(this.buffer.length - len);
+      if (tag.startsWith(suffix)) return this.buffer.length - len;
+    }
+    return -1;
   }
   private compactBuffer(offset: number): void {
     if (this.textEmissionBoundary > MAX_BUFFER_SIZE) {

--- a/src/tools/parser.ts
+++ b/src/tools/parser.ts
@@ -11,6 +11,7 @@ export interface ParserResult {
 }
 const MAX_BUFFER_SIZE = 65536;
 const TRIM_KEEP_CONTEXT = 4096;
+const XML_TOOL_TAGS = ['bash', 'read', 'write', 'edit', 'grep', 'glob', 'task', 'question', 'webfetch', 'skill', 'todowrite'];
 export class StreamingToolParser {
   private buffer = '';
   private emittedCount = 0;
@@ -28,12 +29,27 @@ export class StreamingToolParser {
       const nextBraceQuote = this.buffer.indexOf('{"', offset);
       const nextBraceBracket = this.buffer.indexOf('[{', offset);
       const nextFunctionCalls = this.buffer.indexOf('<function_calls>', offset);
+      const nextSingleXml = this.findNextSingleXmlStart(offset);
       let jsonStart = -1;
       let isArray = false;
       if (nextBraceQuote !== -1 && (nextBraceBracket === -1 || nextBraceQuote <= nextBraceBracket)) {
         jsonStart = nextBraceQuote;
       } else if (nextBraceBracket !== -1) { jsonStart = nextBraceBracket; isArray = true; }
-      if (nextFunctionCalls !== -1 && (jsonStart === -1 || nextFunctionCalls < jsonStart)) {
+      const nextXmlStart = this.firstIndex(nextFunctionCalls, nextSingleXml);
+      if (nextXmlStart !== -1 && (jsonStart === -1 || nextXmlStart < jsonStart)) {
+        if (nextXmlStart === nextSingleXml) {
+          if (this.textEmissionBoundary < nextSingleXml) {
+            result.text += this.buffer.substring(this.textEmissionBoundary, nextSingleXml);
+            this.textEmissionBoundary = nextSingleXml;
+          }
+          const xmlResult = this.extractSingleXmlToolCall(nextSingleXml);
+          if (!xmlResult) { break; }
+          result.toolCalls.push(...xmlResult.toolCalls);
+          this.emittedCount += xmlResult.toolCalls.length;
+          offset = xmlResult.endOffset;
+          this.textEmissionBoundary = offset;
+          continue;
+        }
         if (this.textEmissionBoundary < nextFunctionCalls) {
           result.text += this.buffer.substring(this.textEmissionBoundary, nextFunctionCalls);
           this.textEmissionBoundary = nextFunctionCalls;
@@ -150,6 +166,47 @@ export class StreamingToolParser {
       toolCalls.push({ id: `call_${crypto.randomUUID()}`, name, arguments: args });
     }
     return { toolCalls, endOffset };
+  }
+  private extractSingleXmlToolCall(startIdx: number): { toolCalls: ParsedToolCall[]; endOffset: number } | null {
+    const open = this.buffer.substring(startIdx).match(/^<([A-Za-z][A-Za-z0-9_]*)>/);
+    if (!open) return null;
+    const rawTag = open[1];
+    const name = this.xmlToolName(rawTag);
+    if (!name) return null;
+    const closeTag = `</${rawTag}>`;
+    const endIdx = this.buffer.indexOf(closeTag, startIdx + open[0].length);
+    if (endIdx === -1) return null;
+    const endOffset = endIdx + closeTag.length;
+    const inner = this.buffer.substring(startIdx + open[0].length, endIdx);
+    const args: Record<string, unknown> = {};
+    const paramRe = /<(?:parameter|param)\s+name="([^"]+)"\s*>([\s\S]*?)<\/(?:parameter|param)>/g;
+    let param: RegExpExecArray | null;
+    while ((param = paramRe.exec(inner))) {
+      const key = param[1].trim();
+      if (!key) continue;
+      const rawValue = this.decodeXml(param[2].trim());
+      args[key] = /^-?\d+(?:\.\d+)?$/.test(rawValue) ? Number(rawValue) : rawValue;
+    }
+    return { toolCalls: [{ id: `call_${crypto.randomUUID()}`, name, arguments: args }], endOffset };
+  }
+  private xmlToolName(rawTag: string): string | null {
+    if (/^ToolRead$/i.test(rawTag)) return 'read';
+    const lower = rawTag.toLowerCase();
+    return XML_TOOL_TAGS.includes(lower) ? lower : null;
+  }
+  private findNextSingleXmlStart(offset: number): number {
+    const re = /<([A-Za-z][A-Za-z0-9_]*)>/g;
+    re.lastIndex = offset;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(this.buffer))) {
+      if (this.xmlToolName(match[1])) return match.index;
+    }
+    return -1;
+  }
+  private firstIndex(a: number, b: number): number {
+    if (a === -1) return b;
+    if (b === -1) return a;
+    return Math.min(a, b);
   }
   private decodeXml(text: string): string {
     return text


### PR DESCRIPTION
## Summary
- Strengthen tool-call prompting to require plain JSON tool-call objects and avoid Qwen-native wrappers/XML/markdown.
- Let the session pool own account selection so failed session creation can throttle a bad account and retry another account.
- Preserve full upstream chats/new error details and isolate auth hot-reload tests from real qwen_profile cookies.

Fixes #3

## Test Plan
- npx tsx --test src/routes/toolPrompt.test.ts src/services/sessionPool.test.ts src/services/auth.test.ts
- Manual chat completion through local gateway with account failover