### PR TITLE
fix: forward OpenAI tools to Qwen payload

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -102,14 +102,16 @@ async function setupSession(
 
   const routedModel = await modelRouter.route(body.model);
   let { stream, abortController: qwenAbortController } =
-    await createQwenStreamWithRetry(
-      sessionMessages,
-      isThinkingModel,
-      routedModel,
-      session.chatId,
-      nextParentId,
-      resolvedEmail,
-    );
+      await createQwenStreamWithRetry(
+        sessionMessages,
+        isThinkingModel,
+        routedModel,
+        session.chatId,
+        nextParentId,
+        resolvedEmail,
+        body.tools,
+        typeof body.tool_choice === 'string' ? body.tool_choice : undefined,
+      );
 
   // Build finalPrompt for logStore debug logging only
   const finalPrompt = sessionMessages.map((m: any) => {

--- a/src/routes/chatHelpers.ts
+++ b/src/routes/chatHelpers.ts
@@ -334,6 +334,7 @@ export async function createQwenStreamWithRetry(
   nextParentId: string | null,
   resolvedEmail: string,
   tools?: unknown[],
+  toolChoice?: string,
 ): Promise<{ stream: ReadableStream; abortController: AbortController; qwenLogFile?: string }> {
   try {
     const result = await createQwenStream(
@@ -344,6 +345,7 @@ export async function createQwenStreamWithRetry(
       nextParentId,
       resolvedEmail,
       tools,
+      toolChoice,
     );
     modelRouter.recordSuccess(routedModel);
     return { stream: result.stream, abortController: result.abortController, qwenLogFile: result.qwenLogFile };

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -222,6 +222,63 @@ test('Chat Completions returns a JSON chat.completion object for non-streaming r
   }
 });
 
+test('Chat Completions forwards OpenAI tools to Qwen payload', async () => {
+  const originalFetch = globalThis.fetch;
+  let qwenPayload: any = null;
+  globalThis.fetch = async (input: any, init?: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('/api/v2/chat/completions')) {
+      qwenPayload = JSON.parse(String(init?.body || '{}'));
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('data: {"choices": [{"delta": {"phase": "answer", "content": ""}}]}\n\n'));
+          c.enqueue(new TextEncoder().encode('data: [DONE]\n\n'));
+          c.close();
+        }
+      });
+      return new Response(stream, { status: 200 });
+    }
+    return originalFetch(input, init);
+  };
+
+  await initPlaywright(false);
+
+  try {
+    const tools = [{
+      type: 'function' as const,
+      function: {
+        name: 'read',
+        description: 'Read a file',
+        parameters: {
+          type: 'object',
+          properties: { filePath: { type: 'string' } },
+          required: ['filePath'],
+        },
+      },
+    }];
+    const req = new Request('http://localhost/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'qwen3.6-plus',
+        messages: [{ role: 'user', content: 'read package.json' }],
+        tools,
+        tool_choice: 'auto',
+        stream: false,
+      }),
+    });
+
+    const res = await app.fetch(req);
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(qwenPayload.tools, tools);
+    assert.strictEqual(qwenPayload.tool_choice, 'auto');
+    assert.strictEqual(qwenPayload.parallel_tool_calls, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await closePlaywright();
+  }
+});
+
 test('API Key protection', async () => {
   const originalApiKey = process.env.API_KEY;
   process.env.API_KEY = 'test-api-key';


### PR DESCRIPTION
## Summary
- Forward OpenAI-compatible `tools` from `/v1/chat/completions` into the upstream Qwen payload.
- Forward string `tool_choice` so Qwen receives `tool_choice` plus `parallel_tool_calls` when tools are present.
- Add a regression test that captures the upstream Qwen request and verifies `tools`, `tool_choice`, and `parallel_tool_calls` are present.

## Root Cause
`setupSession()` parsed requests containing `body.tools`, and `buildQwenMessages()` built `feature_config.local_mcp`, but the call to `createQwenStreamWithRetry()` omitted `body.tools`. As a result, `createQwenStream()` never included root-level OpenAI tool definitions in the Qwen request payload.

## Impact
Clients could send valid OpenAI tool schemas, but Qwen never received them at the root payload level. Tool calling could then degrade into text/XML-like tool calls, native/local tool phases, or client-side "tool unavailable" failures.

## Test Plan
- `npm test -- src/tests/index.test.ts`
- `npm run build`

## Local Verification
- Regression test failed before the fix with `qwenPayload.tools === undefined`.
- After the fix, the test suite passed with `106 pass, 0 fail`.
- TypeScript build completed successfully.