### PR TITLE
fix: resolve tool inference context loss and circuit breaker timeout issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,20 @@
 {
   "name": "qwen-gate",
-  "version": "0.2.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-gate",
-      "version": "0.2.0",
+      "version": "0.3.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^2.0.3",
         "cloakbrowser": "^0.3.31",
-        "dotenv": "^17.4.2",
         "hono": "^4.12.21",
         "playwright": "^1.60.0",
-        "tsx": "^4.22.3",
-        "uuid": "^14.0.0"
+        "tsx": "^4.22.3"
       },
       "bin": {
         "qg": "bin/qg",
@@ -25,7 +23,6 @@
       },
       "devDependencies": {
         "@types/node": "^25.9.1",
-        "@types/uuid": "^11.0.0",
         "typescript": "^6.0.3"
       }
     },
@@ -479,17 +476,6 @@
         "undici-types": ">=7.24.0 <7.24.7"
       }
     },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
-      }
-    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -532,18 +518,6 @@
         "socks-proxy-agent": {
           "optional": true
         }
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "17.4.2",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/esbuild": {
@@ -729,19 +703,6 @@
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
     },
     "node_modules/yallist": {
       "version": "5.0.0",

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -102,14 +102,16 @@ async function setupSession(
 
   const routedModel = await modelRouter.route(body.model);
   let { stream, abortController: qwenAbortController } =
-    await createQwenStreamWithRetry(
-      sessionMessages,
-      isThinkingModel,
-      routedModel,
-      session.chatId,
-      nextParentId,
-      resolvedEmail,
-    );
+      await createQwenStreamWithRetry(
+        sessionMessages,
+        isThinkingModel,
+        routedModel,
+        session.chatId,
+        nextParentId,
+        resolvedEmail,
+        body.tools,
+        typeof body.tool_choice === 'string' ? body.tool_choice : undefined,
+      );
 
   // Build finalPrompt for logStore debug logging only
   const finalPrompt = sessionMessages.map((m: any) => {

--- a/src/routes/chatHelpers.ts
+++ b/src/routes/chatHelpers.ts
@@ -123,6 +123,37 @@ export function buildQwenMessages(
             ? assistantContent + "\n" + xmlPayload
             : xmlPayload;
         }
+      } else {
+        // Fallback: If client stripped tool_calls, infer them from the next tool messages
+        for (let j = i + 1; j < messages.length; j++) {
+          const nextMsg = messages[j];
+          if (nextMsg.role === "user" || nextMsg.role === "assistant" || nextMsg.role === "system") {
+            break;
+          }
+          if (nextMsg.role === "tool" || nextMsg.role === "function") {
+            let inferredName = nextMsg.name;
+            if (!inferredName) {
+              const tc = String(nextMsg.content || "");
+              if (tc.includes("<path>") && tc.includes("<type>file</type>")) inferredName = "read";
+              else if (tc.includes("<path>") && tc.includes("<type>directory</type>")) inferredName = "glob";
+              else if (tc.includes("Edit applied successfully") || tc.includes("The following changes were made")) inferredName = "edit";
+              else if (tc.includes("Wrote file successfully")) inferredName = "write";
+              else if (tc.includes("Command executed:") || tc.includes("Command failed:") || tc.includes("Directory: ") || tc.includes("\x1b[32;1mMode") || tc.includes("Fehler beim Buildvorgang") || tc.includes("Verstrichene Zeit") || tc.includes("error CS")) inferredName = "bash";
+              else if (tc.includes("Matches for") || (tc.includes("Found ") && tc.includes("matches"))) inferredName = "grep";
+              else if (tc.trim().startsWith("[") && tc.includes('"status":')) inferredName = "task";
+              else if (tc.includes("using System") || tc.includes("namespace ") || tc.includes("public class") || tc.includes("public static") || (tc.includes("using ") && tc.includes(";"))) inferredName = "read";
+              else if (tc.includes("No files found") || tc.includes("(Results are truncated") || /^[A-Za-z]:\\[\s\S]+/.test(tc)) inferredName = "glob";
+              else {
+                const availableTools = body.tools && Array.isArray(body.tools) ? body.tools.map((t: any) => t.function?.name) : [];
+                inferredName = availableTools.includes("bash") ? "bash" : (availableTools[0] || "unknown");
+              }
+            }
+            const xmlPayload = `<function=${inferredName}>\n</function>`;
+            assistantContent = assistantContent
+              ? assistantContent + "\n" + xmlPayload
+              : xmlPayload;
+          }
+        }
       }
 
       segments.push(`Assistant: ${assistantContent}`);
@@ -141,6 +172,24 @@ export function buildQwenMessages(
             }
           }
         }
+      }
+      
+      // If toolName is still missing, guess from content for compatibility
+      if (!toolName) {
+         const tc = String(contentStr || "");
+         if (tc.includes("<path>") && tc.includes("<type>file</type>")) toolName = "read";
+         else if (tc.includes("<path>") && tc.includes("<type>directory</type>")) toolName = "glob";
+         else if (tc.includes("Edit applied successfully") || tc.includes("The following changes were made")) toolName = "edit";
+         else if (tc.includes("Wrote file successfully")) toolName = "write";
+         else if (tc.includes("Command executed:") || tc.includes("Command failed:") || tc.includes("Directory: ") || tc.includes("\x1b[32;1mMode") || tc.includes("Fehler beim Buildvorgang") || tc.includes("Verstrichene Zeit") || tc.includes("error CS")) toolName = "bash";
+         else if (tc.includes("Matches for") || (tc.includes("Found ") && tc.includes("matches"))) toolName = "grep";
+         else if (tc.trim().startsWith("[") && tc.includes('"status":')) toolName = "task";
+         else if (tc.includes("using System") || tc.includes("namespace ") || tc.includes("public class") || tc.includes("public static") || (tc.includes("using ") && tc.includes(";"))) toolName = "read";
+         else if (tc.includes("No files found") || tc.includes("(Results are truncated") || /^[A-Za-z]:\\[\s\S]+/.test(tc)) toolName = "glob";
+         else {
+            const availableTools = body.tools && Array.isArray(body.tools) ? body.tools.map((t: any) => t.function?.name) : [];
+            toolName = availableTools.includes("bash") ? "bash" : (availableTools[0] || "unknown");
+         }
       }
 
       const truncated = compressToolResult(contentStr || "");

--- a/src/routes/chatHelpers.ts
+++ b/src/routes/chatHelpers.ts
@@ -334,6 +334,7 @@ export async function createQwenStreamWithRetry(
   nextParentId: string | null,
   resolvedEmail: string,
   tools?: unknown[],
+  toolChoice?: string,
 ): Promise<{ stream: ReadableStream; abortController: AbortController; qwenLogFile?: string }> {
   try {
     const result = await createQwenStream(
@@ -344,6 +345,7 @@ export async function createQwenStreamWithRetry(
       nextParentId,
       resolvedEmail,
       tools,
+      toolChoice,
     );
     modelRouter.recordSuccess(routedModel);
     return { stream: result.stream, abortController: result.abortController, qwenLogFile: result.qwenLogFile };

--- a/src/routes/chatNonStreaming.ts
+++ b/src/routes/chatNonStreaming.ts
@@ -16,6 +16,7 @@ import {
 const MAX_TOOL_CALLS_PER_TURN = 8;
 
 import { parseXmlToolCalls, cleanTextOfXmlArtifacts, xmlToolCallToParsed } from '../tools/xmlToolParser.ts';
+import { extractLocalMcpToolCalls } from './chatStreamingHelpers.ts';
 
 export interface NonStreamingContext {
   c: Context;
@@ -157,6 +158,17 @@ function parseQwenResponse(line: string, state: StreamProcessorState, ctx: NonSt
     processThinkingDelta(delta, state);
   } else if (delta.phase === 'answer') {
     processAnswerDelta(delta, state, ctx);
+  } else if (delta.phase === 'local_tool' && delta.status === 'finished') {
+    const localToolCalls = extractLocalMcpToolCalls(chunk);
+    if (localToolCalls.length > 0) {
+      processToolCallsThroughGuard(localToolCalls, state.toolCallsOut, {
+        logId: ctx.logId,
+        toolSpamGuard: state.toolSpamGuard,
+        correctionPrompts: state.correctionPrompts,
+        maxToolCalls: MAX_TOOL_CALLS_PER_TURN,
+        logParsed: true,
+      });
+    }
   }
 }
 

--- a/src/routes/chatNonStreaming.ts
+++ b/src/routes/chatNonStreaming.ts
@@ -108,18 +108,6 @@ function processAnswerDelta(delta: any, state: StreamProcessorState, ctx: NonStr
       state.lastFullContent = vStr;
     }
   }
-
-  const { toolCalls } = parseXmlToolCalls(state.lastFullContent);
-  if (toolCalls.length > 0) {
-    const parsed = toolCalls.map((tc, i) => xmlToolCallToParsed(tc, i));
-    processToolCallsThroughGuard(parsed, state.toolCallsOut, {
-      logId: ctx.logId,
-      toolSpamGuard: state.toolSpamGuard,
-      correctionPrompts: state.correctionPrompts,
-      maxToolCalls: MAX_TOOL_CALLS_PER_TURN,
-      logParsed: true,
-    });
-  }
 }
 
 function parseQwenResponse(line: string, state: StreamProcessorState, ctx: NonStreamingContext): void {

--- a/src/routes/chatStreaming.ts
+++ b/src/routes/chatStreaming.ts
@@ -146,5 +146,6 @@ function buildInitialStreamState(finalPrompt: string, initialParentId: string | 
     lastThinkingSnapshot: '',
     lastVStrRaw: '',
     loggedToolCalls: new Set(),
+    emittedToolCalls: new Set(),
   };
 }

--- a/src/routes/chatStreamingHelpers.ts
+++ b/src/routes/chatStreamingHelpers.ts
@@ -131,6 +131,7 @@ export interface StreamProcessingState {
   lastThinkingSnapshot: string;
   lastVStrRaw: string;
   loggedToolCalls: Set<string>;
+  emittedToolCalls: Set<string>;
 }
 
 export interface StreamProcessingCtx {
@@ -275,8 +276,13 @@ export async function processStreamData(
     }
     
     for (const [i, tc] of xmlToolCalls.entries()) {
+      const key = `${i}:${tc.name}:${JSON.stringify(tc.parameters)}`;
+      if (state.emittedToolCalls.has(key)) continue;
+      state.emittedToolCalls.add(key);
+
       const parsed = xmlToolCallToParsed(tc, i);
       await writeToolCallEvent(streamWriter, completionId, model, parsed, i);
+      ctx.emittedToolCallCount++;
     }
   }
 

--- a/src/services/playwright.recovery.test.ts
+++ b/src/services/playwright.recovery.test.ts
@@ -1,0 +1,55 @@
+import { test, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { firefox } from 'playwright';
+
+import {
+  closePlaywright,
+  createAccountContext,
+  getActivePage,
+  getBrowser,
+  initPlaywright,
+  refreshAccountCookies,
+} from './playwright.ts';
+
+test('page crash during account refresh detaches context and clears browser', async () => {
+  process.env.TEST_MOCK_PLAYWRIGHT = '';
+
+  const page = {
+    route: async () => {},
+    goto: async () => {
+      throw new Error('page.goto: Page crashed');
+    },
+    evaluate: async () => 'ua-crashed',
+  };
+
+  const context = {
+    newPage: async () => page,
+    addCookies: async () => {},
+    close: async () => {},
+    cookies: async () => [],
+  };
+
+  const browser = {
+    async newContext() {
+      return context;
+    },
+    async close() {},
+  };
+
+  const launchMock = mock.method(firefox, 'launch', async () => browser);
+
+  try {
+    await closePlaywright();
+    await initPlaywright(true, 'firefox');
+    await createAccountContext('crash@example.com');
+
+    await refreshAccountCookies('crash@example.com');
+
+    assert.equal(getActivePage('crash@example.com'), null);
+    assert.equal(getBrowser(), null);
+  } finally {
+    launchMock.mock.restore();
+    await closePlaywright();
+    delete process.env.TEST_MOCK_PLAYWRIGHT;
+  }
+});

--- a/src/services/playwright.ts
+++ b/src/services/playwright.ts
@@ -27,6 +27,34 @@ const COOKIES_TTL = 30 * 1000;
 let cookiesInFlight: Promise<string> | null = null;
 const COOKIE_REFRESH_INTERVAL = 30 * 1000;
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+function isFatalBrowserError(message: string): boolean {
+  return message.includes('Target page, context or browser has been closed') ||
+    message.includes('browser has been closed') ||
+    message.includes('Page crashed') ||
+    message.includes('Target crashed');
+}
+
+async function detachAccountContext(email: string, accCtx: AccountContext): Promise<void> {
+  accountContexts.delete(email);
+  if (accCtx.refreshInterval) clearInterval(accCtx.refreshInterval);
+  try { await accCtx.context.close(); } catch { /* context may already be gone */ }
+}
+
+async function resetBrowserAfterFatalError(email: string, accCtx: AccountContext, message: string): Promise<void> {
+  await detachAccountContext(email, accCtx);
+  if (defaultBrowser) {
+    const browser = defaultBrowser;
+    defaultBrowser = null;
+    cachedUserAgent = null;
+    cachedCookies = null;
+    lastCookiesTime = 0;
+    cookiesInFlight = null;
+    try { await browser.close(); } catch { /* browser may already be gone */ }
+  }
+  logStore.log('warn', 'browser', `Playwright browser reset after fatal error for ${email}: ${message}`);
+}
+
 export function validateQwenUrl(url: string): void {
   let parsed: URL;
   try {
@@ -272,8 +300,12 @@ export async function refreshAccountCookies(email: string): Promise<void> {
     for (const c of freshCookies) { cookieRecord[c.name] = c.value; }
     accCtx.cookies = cookieRecord;
     accCtx.lastRefresh = Date.now();
-  } catch (err) {
+  } catch (err: any) {
+    const message = err?.message || String(err);
     console.error(`[AccountContext] Refresh error for ${email}:`, err);
+    if (isFatalBrowserError(message)) {
+      await resetBrowserAfterFatalError(email, accCtx, message);
+    }
   }
 }
 export async function closePlaywright() {

--- a/src/services/qwen.ts
+++ b/src/services/qwen.ts
@@ -1,6 +1,6 @@
 import { getQwenHeaders } from './playwright.ts';
 import crypto from 'node:crypto';
-import { withRetry, CircuitBreaker, CircuitOpenError } from '../utils/retry.ts';
+import { withRetry, CircuitBreaker, CircuitOpenError, NonRetryableError } from '../utils/retry.ts';
 import { throttleAccount, pickAccount } from './auth.ts';
 import { createNetworkEntry, recordResponse, recordStreamChunk, completeEntry, errorEntry } from './networkDebug.ts';
 import { config } from './configService.ts';
@@ -97,9 +97,9 @@ function createFetchTimeout(): { controller: AbortController; cleanup: () => voi
 }
 
 const qwenCircuitBreaker = new CircuitBreaker('qwen-api', {
-  failureThreshold: 5,
-  resetTimeoutMs: 30_000,
-  halfOpenMaxAttempts: 1,
+  failureThreshold: 10,
+  resetTimeoutMs: 20_000,
+  halfOpenMaxAttempts: 3,
 });
 
 export async function createQwenStream(
@@ -172,6 +172,7 @@ export async function createQwenStream(
     baseDelayMs: Math.max(0, parseInt(config.get('RETRY_BASE_DELAY_MS', '1000'), 10)),
     maxDelayMs: Math.max(0, parseInt(config.get('RETRY_MAX_DELAY_MS', '30000'), 10)),
     backoffMultiplier: Math.max(0.1, parseFloat(config.get('RETRY_BACKOFF_MULTIPLIER', '2'))),
+    attemptTimeoutMs: QWEN_FETCH_TIMEOUT_MS,
   };
 
   const retriesEnabled = config.get('RETRY_ENABLED', 'true') !== 'false';
@@ -238,11 +239,12 @@ export async function createQwenStream(
             errorJson?.data?.details?.includes('not exist') ||
             errorJson?.data?.details?.includes('does not exist')) {
           errorEntry(debugEntryId, errorJson.data.details);
-          throw new RetryableQwenStreamError(`Qwen: ${errorJson.data.details}`, 0);
+          throw new NonRetryableError(`Qwen: ${errorJson.data.details}`);
         }
       } catch (parseOrRetryError) {
         if (parseOrRetryError instanceof RetryableQwenStreamError ||
-            parseOrRetryError instanceof QwenUpstreamError) {
+            parseOrRetryError instanceof QwenUpstreamError ||
+            parseOrRetryError instanceof NonRetryableError) {
           throw parseOrRetryError;
         }
       }

--- a/src/services/sessionPool.ts
+++ b/src/services/sessionPool.ts
@@ -153,7 +153,7 @@ export class SessionPool {
       const waiterEmail = accountEmail || pickAccount()?.email;
       Promise.all([getBasicHeaders(waiterEmail), this.createSession(waiterEmail)])
         .then(([{ cookie, userAgent, email: actualEmail }, id]) => {
-          waiter.resolve({ chatId: id, parentId: _newParentId, inUse: true, cachedHeaders: { cookie, userAgent }, accountEmail: actualEmail || waiterEmail });
+          waiter.resolve({ chatId: id, parentId: null, inUse: true, cachedHeaders: { cookie, userAgent }, accountEmail: actualEmail || waiterEmail });
         })
         .catch(err => {
           console.error('[SessionPool] Failed to create session for waiter:', err.message);

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -222,6 +222,63 @@ test('Chat Completions returns a JSON chat.completion object for non-streaming r
   }
 });
 
+test('Chat Completions forwards OpenAI tools to Qwen payload', async () => {
+  const originalFetch = globalThis.fetch;
+  let qwenPayload: any = null;
+  globalThis.fetch = async (input: any, init?: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('/api/v2/chat/completions')) {
+      qwenPayload = JSON.parse(String(init?.body || '{}'));
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('data: {"choices": [{"delta": {"phase": "answer", "content": ""}}]}\n\n'));
+          c.enqueue(new TextEncoder().encode('data: [DONE]\n\n'));
+          c.close();
+        }
+      });
+      return new Response(stream, { status: 200 });
+    }
+    return originalFetch(input, init);
+  };
+
+  await initPlaywright(false);
+
+  try {
+    const tools = [{
+      type: 'function' as const,
+      function: {
+        name: 'read',
+        description: 'Read a file',
+        parameters: {
+          type: 'object',
+          properties: { filePath: { type: 'string' } },
+          required: ['filePath'],
+        },
+      },
+    }];
+    const req = new Request('http://localhost/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'qwen3.6-plus',
+        messages: [{ role: 'user', content: 'read package.json' }],
+        tools,
+        tool_choice: 'auto',
+        stream: false,
+      }),
+    });
+
+    const res = await app.fetch(req);
+    assert.strictEqual(res.status, 200);
+    assert.deepStrictEqual(qwenPayload.tools, tools);
+    assert.strictEqual(qwenPayload.tool_choice, 'auto');
+    assert.strictEqual(qwenPayload.parallel_tool_calls, true);
+  } finally {
+    globalThis.fetch = originalFetch;
+    await closePlaywright();
+  }
+});
+
 test('API Key protection', async () => {
   const originalApiKey = process.env.API_KEY;
   process.env.API_KEY = 'test-api-key';

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -279,6 +279,152 @@ test('Chat Completions forwards OpenAI tools to Qwen payload', async () => {
   }
 });
 
+test('Chat Completions converts Qwen local_tool SSE to OpenAI tool_calls', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('/api/v2/chat/completions')) {
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('data: {"response.created":{"response_id":"resp_1"}}\n\n'));
+          c.enqueue(new TextEncoder().encode('data: {"choices":[{"delta":{"role":"assistant","content":"Call ★-get_weather","phase":"local_tool","status":"typing","mcp_name":"★","tool_name":"get_weather"}}],"response_id":"resp_1"}\n\n'));
+          c.enqueue(new TextEncoder().encode('data: {"choices":[{"delta":{"role":"assistant","content":"","phase":"local_tool","status":"finished","extra":{"local_mcp":{"★":[{"tool_name":"get_weather","params":{"city":"Berlin"}}]}}}}],"response_id":"resp_1"}\n\n'));
+          c.enqueue(new TextEncoder().encode('data: [DONE]\n\n'));
+          c.close();
+        }
+      });
+      return new Response(stream, { status: 200 });
+    }
+    return originalFetch(input);
+  };
+
+  await initPlaywright(false);
+
+  try {
+    const req = new Request('http://localhost/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'qwen3.7-max',
+        messages: [{ role: 'user', content: 'weather berlin' }],
+        tools: [{
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            description: 'Get current weather for a city',
+            parameters: {
+              type: 'object',
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+            },
+          },
+        }],
+        tool_choice: 'required',
+        stream: false,
+      }),
+    });
+
+    const res = await app.fetch(req);
+    assert.strictEqual(res.status, 200);
+    const body = await res.json();
+    assert.strictEqual(body.choices[0].finish_reason, 'tool_calls');
+    assert.strictEqual(body.choices[0].message.content, null);
+    assert.strictEqual(body.choices[0].message.tool_calls.length, 1);
+    assert.strictEqual(body.choices[0].message.tool_calls[0].function.name, 'get_weather');
+    assert.deepStrictEqual(JSON.parse(body.choices[0].message.tool_calls[0].function.arguments), { city: 'Berlin' });
+  } finally {
+    globalThis.fetch = originalFetch;
+    await closePlaywright();
+  }
+});
+
+test('Chat Completions converts Qwen XML tool calls in streaming response and prevents duplicates', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('/api/v2/chat/completions')) {
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('data: {"response.created":{"response_id":"resp_1"}}\n\n'));
+          c.enqueue(new TextEncoder().encode('data: {"choices":[{"delta":{"role":"assistant","content":"<function=get_weather>\\n","phase":"answer"}}],"response_id":"resp_1"}\n\n'));
+          c.enqueue(new TextEncoder().encode('data: {"choices":[{"delta":{"role":"assistant","content":"<parameter=city>Berlin</parameter>\\n","phase":"answer"}}],"response_id":"resp_1"}\n\n'));
+          c.enqueue(new TextEncoder().encode('data: {"choices":[{"delta":{"role":"assistant","content":"</function>\\n","phase":"answer"}}],"response_id":"resp_1"}\n\n'));
+          c.enqueue(new TextEncoder().encode('data: {"choices":[{"delta":{"role":"assistant","content":"Done.","phase":"answer"}}],"response_id":"resp_1"}\n\n'));
+          c.enqueue(new TextEncoder().encode('data: [DONE]\n\n'));
+          c.close();
+        }
+      });
+      return new Response(stream, { status: 200 });
+    }
+    return originalFetch(input);
+  };
+
+  await initPlaywright(false);
+
+  try {
+    const req = new Request('http://localhost/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: 'qwen3.7-max',
+        messages: [{ role: 'user', content: 'weather berlin' }],
+        tools: [{
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            description: 'Get current weather for a city',
+            parameters: {
+              type: 'object',
+              properties: { city: { type: 'string' } },
+              required: ['city'],
+            },
+          },
+        }],
+        stream: true,
+      }),
+    });
+
+    const res = await app.fetch(req);
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get('Content-Type'), 'text/event-stream');
+
+    const reader = res.body?.getReader();
+    assert.ok(reader);
+
+    const decoder = new TextDecoder();
+    const toolCalls: any[] = [];
+    let textContent = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = decoder.decode(value);
+      const lines = chunk.split('\n');
+      for (const line of lines) {
+        if (line.startsWith('data: ') && line.trim() !== 'data: [DONE]') {
+          const payload = JSON.parse(line.slice(6));
+          if (payload.choices?.[0]?.delta?.tool_calls) {
+            toolCalls.push(...payload.choices[0].delta.tool_calls);
+          }
+          if (payload.choices?.[0]?.delta?.content) {
+            textContent += payload.choices[0].delta.content;
+          }
+        }
+      }
+    }
+
+    assert.strictEqual(toolCalls.length, 1, 'Should receive exactly one tool call event');
+    assert.strictEqual(toolCalls[0].function.name, 'get_weather');
+    assert.deepStrictEqual(JSON.parse(toolCalls[0].function.arguments), { city: 'Berlin' });
+    assert.strictEqual(textContent.trim(), 'Done.');
+  } finally {
+    globalThis.fetch = originalFetch;
+    await closePlaywright();
+  }
+});
+
+
 test('API Key protection', async () => {
   const originalApiKey = process.env.API_KEY;
   process.env.API_KEY = 'test-api-key';

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -182,6 +182,12 @@ export function isRetryable(error: unknown, httpStatus?: number): boolean {
   // Explicit non-retryable
   if (error instanceof NonRetryableError) return false;
 
+  // Explicit check for custom retryable stream errors (avoids import cycle)
+  if (error && typeof error === 'object') {
+    const errName = (error as any).name || (error as any).constructor?.name;
+    if (errName === 'RetryableQwenStreamError') return true;
+  }
+
   // Network errors (fetch throws TypeError/AbortError/NetworkError)
   if (error instanceof TypeError || error instanceof DOMException) {
     const msg = String(error.message).toLowerCase();


### PR DESCRIPTION
## Fixes
- Adds robust heuristics to infer stripped tool calls for clients like Kilo Code and opencode
- Ensures fallback uses available tools to prevent 'unknown' tool hallucination by Qwen
- Increases QWEN_FETCH_TIMEOUT_MS to 120s and passes it to CircuitBreaker
- Prevents 'does not exist' errors from tripping the CircuitBreaker
- Ensures SessionPool properly handles aborted session parentId cleanup