### PR TITLE
fix: add Playwright browser install to installers + robust watchdog script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -114,6 +114,20 @@ if ($UseBun) {
   Ok "Dependencies installed via npm"
 }
 
+# ── 4b. Install Playwright browsers ────────────────────────────────
+
+Info "Installing Playwright browsers..."
+try {
+  npx playwright install 2>$null
+  if ($LASTEXITCODE -ne 0) {
+    Warn "Playwright browser install returned non-zero exit code — continuing anyway"
+  } else {
+    Ok "Playwright browsers installed"
+  }
+} catch {
+  Warn "Playwright browser install failed — continuing anyway ($_ )"
+}
+
 # ── 5. Configuration ────────────────────────────────────────────────
 
 if (-not (Test-Path "$Dir\config.json")) {

--- a/install.sh
+++ b/install.sh
@@ -105,6 +105,14 @@ else
 fi
 ok "Dependencies installed"
 
+# ── Step 4b: Install Playwright browsers ─────────────────────────────
+info "Installing Playwright browsers..."
+if npx playwright install 2>/dev/null; then
+  ok "Playwright browsers installed"
+else
+  warn "Playwright browser install failed — continuing anyway"
+fi
+
 # ── Step 5: Create config.json ───────────────────────────────────────
 if [ ! -f config.json ]; then
   if [ -f config.example.jsonc ]; then

--- a/start-server.ps1
+++ b/start-server.ps1
@@ -1,0 +1,55 @@
+Start-Transcript -Path "$env:USERPROFILE\qwen-gate\startup.log" -Append
+
+$ServerDir = "$env:USERPROFILE\qwen-gate\qwen-gate-latest"
+$NodeExe = "node"
+$Entry = "$ServerDir\src\index.tsx"
+$Port = 26405
+
+Write-Host "[$(Get-Date)] Starting qwen-gate server..."
+
+# Kill any existing server on port
+$existingProc = netstat -ano | Select-String ":$Port\s+.*LISTENING" | ForEach-Object { ($_ -split '\s+')[-1] } | Select-Object -First 1
+if ($existingProc -and $existingProc -ne '0') {
+    Write-Host "[$(Get-Date)] Port $Port in use by PID $existingProc - killing..."
+    Stop-Process -Id $existingProc -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 2
+}
+
+# Verify Playwright browsers exist
+$playwrightPath = "$env:LOCALAPPDATA\ms-playwright"
+if (-not (Test-Path $playwrightPath) -or (Get-ChildItem $playwrightPath -ErrorAction SilentlyContinue).Count -eq 0) {
+    Write-Host "[$(Get-Date)] Playwright browsers not found - installing..."
+    Set-Location $ServerDir
+    npx playwright install 2>&1 | Write-Host
+}
+
+# Start server loop (restart on crash)
+$env:HOST = "0.0.0.0"
+while ($true) {
+    # Pre-check port availability
+    $portInUse = netstat -ano | Select-String ":$Port\s+.*LISTENING"
+    if ($portInUse) {
+        $blockingPid = ($portInUse -split '\s+')[-1]
+        Write-Host "[$(Get-Date)] Port $Port still in use by PID $blockingPid - killing..."
+        Stop-Process -Id $blockingPid -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 2
+    }
+    
+    Write-Host "[$(Get-Date)] Starting server..."
+    $proc = Start-Process -FilePath $NodeExe -ArgumentList "--import","tsx",$Entry -WorkingDirectory $ServerDir -PassThru -NoNewWindow -RedirectStandardOutput "$env:USERPROFILE\qwen-gate\server-stdout.log" -RedirectStandardError "$env:USERPROFILE\qwen-gate\server-stderr.log"
+    Write-Host "[$(Get-Date)] Server started (PID: $($proc.Id))"
+    
+    # Wait for server to exit
+    $proc.WaitForExit()
+    $exitCode = $proc.ExitCode
+    
+    # Check stderr for crash details
+    $stderrContent = Get-Content "$env:USERPROFILE\qwen-gate\server-stderr.log" -ErrorAction SilentlyContinue
+    if ($stderrContent) {
+        Write-Host "[$(Get-Date)] Server crashed with errors:"
+        $stderrContent | Select-Object -First 10 | Write-Host
+    }
+    
+    Write-Host "[$(Get-Date)] Server exited with code $exitCode - restarting in 5s..."
+    Start-Sleep -Seconds 5
+}


### PR DESCRIPTION
## Changes

- **install.ps1 / install.sh**: Added \
px playwright install\ step after dependency installation to ensure Playwright browsers are always available post-install (previously missing, causing server crash on startup)
- **start-server.ps1**: New robust watchdog script with:
  - Port pre-check (kills zombie processes blocking port 26405 before start)
  - Playwright browser validation (auto-installs if missing)
  - stderr crash logging on exit
  - Clean restart loop with 5s cooldown

## Root Cause

The server was crashing in a loop due to:
1. Missing Playwright browser binaries (\
px playwright install\ was never called by installers or postinstall)
2. Zombie node processes holding port 26405 (EADDRINUSE)
3. No stderr capture in the old watchdog to diagnose crashes

These fixes make the installer fully self-contained — no manual post-install steps required.