### PR TITLE
docs: update docs for releases v0.3.0-v0.7.2 and browserless architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ src/
   routes/               API handlers + streaming logic
     dashboard/          Web dashboard (monitoring, accounts, logs, network, settings)
   tools/                Tool call system (parser, guard, schema, registry)
-  services/             Auth, accounts, sessions, Playwright, logStore, config
+  services/             Auth, accounts, sessions, Qwen API transport, logStore, config
   utils/                Shared utilities
   middleware/           Rate limiter
   types/                TypeScript interfaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-06-23
+
+### Fixed
+- **wreq-js Session Leak**: Explicitly close wreq-js sessions after every use to prevent tokio epoll `Bad file descriptor` crash. Sessions were created per-request (5-10 per request) but never disposed — the Rust tokio runtime continued polling on epoll fds after JS GC'd the wrapper objects. Now all sessions are closed on completion, error, and background timer paths.
+
+## [0.7.1] - 2026-06-23
+
+### Changed
+- **Per-Request wreq-js Sessions**: Switch to fresh wreq-js session per request to avoid tokio epoll/Bun event loop conflict (`Bad file descriptor` panic).
+- **Single File Upload**: Merged `system.txt` + `tool-result.txt` into one `context.txt` with `<system-instructions>` and `<tool-results>` sections. Cuts upload latency in half (4 network hops instead of 8).
+- **Parse Poll Timeout**: Reduced `pollParseStatus` max wait from 60s to 5s. Worst-case upload delay from 60s to 5s.
+- **Boot Account Config**: Apply system prompt + disable native tools at startup via `configureAccount()` call.
+
+### Fixed
+- **System Prompt Clarity**: Updated `defaultSystemPrompt.ts` — tool results are file-only, removed misleading "identical to instructions" claim.
+- **Dead Code**: Removed unused `applyRequestJitter` function from `qwen.ts`.
+
+## [0.7.0] - 2026-06-22
+
+### Changed
+- **Browserless Fetch Stack**: Replaced Playwright entirely with wreq-js based Qwen API interaction. No browser needed for requests.
+- **bx-ua Generator**: Pure Node.js UA generation replaces Playwright extraction.
+- **Test Mode Fetch**: `browserlessFetch` uses `globalThis.fetch` in test mode.
+- **Removed Playwright Dependency**: Removed from `getBasicHeaders()`, removed dead playwright import and `buildRequestHeaders` from `qwen.ts`.
+
+## [0.6.0] - 2026-06-19
+
+### Added
+- **Auto-Upload Large Payloads**: Large payloads auto-upload as Qwen file attachments. Latest user message stays inline, history goes to file.
+- **Dark Mode Toggle**: Added dark mode toggle in sidebar.
+- **Typed Config**: Password master key, health endpoint, rate limiting.
+
+### Changed
+- **Node.js Fetch for All API Calls**: Removed CDP routing. All API calls go through Node.js fetch.
+- **Headless Detection Evasion**: UA rotation and bot detection logging.
+- **Per-Account CDP Browser Contexts**: Startup order fixes, bot detection logging, account routing fixes.
+- **Upload Format**: XML tool result format, .txt file uploads, system prompt update.
+- **Dashboard**: Logs page removed from dashboard.
+- **Code Quality**: Biome format, bug fixes, dead code removal, docs audit.
+
+### Fixed
+- **Qwen CAPTCHA Detection**: Handles `FAIL_SYS_USER_VALIDATE` CAPTCHA responses.
+- **Browser Context Leak**: Orphan process prevention.
+- **Session Pool Hang**: Fixed `sessionPool.acquire()` from hanging indefinitely.
+
 ## [0.5.1] - 2026-06-16
 
 ### Changed
@@ -28,6 +73,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Dashboard Script Injection**: Fixed critical bug where `serveHtml` broke all `<script src="...">` tags when injecting `window.APP_VERSION`. ([#5](https://github.com/youssefvdel/qwen-gate/issues/5))
+
+## [0.4.0] - 2026-06-11
+
+### Added
+- **CDP Routing**: Route Qwen API through real Chrome via CDP to bypass baxia WAF.
+- **Profile-Based Auth**: Read tokens from Chromium browser profiles directly. Auto-detect system Chrome profiles.
+- **Parallel Extraction**: Parallel profile/cookie extraction at startup.
+
+### Changed
+- **Per-Account Browser Contexts**: Isolated CDP browser contexts per account.
+- **Two-Phase Body Storage**: Large CDP request body storage for 132KB+ payloads.
+- **Auth Rewrite**: Removed cookie folder system, refactored to Chromium profile auth.
+
+### Fixed
+- **Dashboard Script Injection**: Script injection breaking all dashboard pages (credit @eric).
+- **Refresh Token TTL**: Fixed refresh token TTL, saves refresh token + expiry.
+- **InFlight Counter Leak**: Fixed inFlight counter leak, deduplicated tool call logging.
+- **XML Leak Prevention**: Hardened XML leak prevention across all emission paths.
+- **Dashboard with API_KEY**: Fixed dashboard when `API_KEY` is set.
+
+## [0.3.1] - 2026-06-09
+
+### Changed
+- **Install Script Fixes**: Removed `set -e`, handle pipes, don't delete node_modules before install.
+- **XML Tool Call Parsing**: Improved XML tool call parsing.
+- **Per-Account Configuration**: Added per-account configuration support.
+- **Install Build Step**: Added build step to install process.
+
+## [0.3.0] - 2026-06-08
+
+### Changed
+- **Native XML Tool Calling**: Major refactor to Qwen native XML tool calling — `<function=name>` format replaces JSON tool calling.
+- **Single Role User**: Flattened messages to single `role:user` (Qwen limitation).
+- **Tool Result Format**: Tool results use `type:function` + `tool:name` format.
+- **Removed Echo Detection**: Removed echo detection, reworked XML stripping.
+
+### Added
+- **MCP Tool Call Extraction**: Extract MCP tool calls from SSE `extra.local_mcp`.
+- **Qwen API Request Logging**: Request logging to `logs/qwen/`.
+- **QwenBaseUrl Config**: Added `QwenBaseUrl` config support.
+- **Account Failover**: Account failover loop (community PR).
+
+### Fixed
+- **Cross-Platform Install Scripts**: Fixed install scripts for cross-platform reliability.
 
 ## [0.2.0] - 2026-06-04
 
@@ -95,7 +184,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Package.json with core dependencies
 - Basic README with project description
 
+[0.7.0]: https://github.com/youssefvdel/qwen-gate/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/youssefvdel/qwen-gate/compare/v0.5.1...v0.6.0
 [0.5.0]: https://github.com/youssefvdel/qwen-gate/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/youssefvdel/qwen-gate/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/youssefvdel/qwen-gate/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/youssefvdel/qwen-gate/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/youssefvdel/qwen-gate/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/youssefvdel/qwen-gate/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/youssefvdel/qwen-gate/releases/tag/v0.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ src/
 ├── middleware/      # Rate limiter
 ├── routes/         # API handlers + streaming
 │   └── dashboard/  # Web dashboard
-├── services/       # Auth, accounts, sessions, Playwright, config
+├── services/       # Auth, accounts, sessions, Qwen API transport, config
 ├── tests/          # Integration tests
 ├── tools/          # Tool calling system
 ├── types/          # OpenAI-compatible types

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Bun](https://img.shields.io/badge/Bun-1.3+-pink.svg)](https://bun.sh/)
 [![GitHub Release](https://img.shields.io/github/v/release/youssefvdel/qwen-gate)](https://github.com/youssefvdel/qwen-gate/releases)
 [![TypeScript](https://img.shields.io/badge/TypeScript-6.0-blue)](https://www.typescriptlang.org/)
-[![Playwright](https://img.shields.io/badge/Powered%20by-Playwright-blueviolet)](https://playwright.dev/)
+[![Browserless](https://img.shields.io/badge/Stack-Browserless-8B5CF6)](https://bun.sh)
 
 > **Disclaimer**: This project is for educational and study purposes. It provides access to Qwen models via `chat.qwen.ai` browser automation. Not affiliated with Alibaba Group or Qwen. Users must comply with `chat.qwen.ai`'s terms of service.
 
@@ -34,7 +34,8 @@ Then open [http://localhost:26405/dashboard](http://localhost:26405/dashboard) t
 - **Streaming SSE** — Server-Sent Events with heartbeat keep-alive and content filter integrity maintained across stream boundaries.
 - **Content Filter Pipeline** — Strips thinking tags and filters internal artifacts from model output.
 - **Web Dashboard** — Real-time monitoring with 5 pages: overview, request log, account manager, network debug, and settings.
-- **Stealth Browser Automation** — Uses CloakBrowser with anti-detection patches to maintain session integrity.
+- **Dual Transport** — Pure Node.js fetch via wreq-js for requests, Playwright browser automation for login/auth only. No browser needed for API calls.
+- **File Upload** — Large context payloads auto-uploaded as Qwen file attachments. Context above limit goes to `context.txt`, latest user message stays inline for low latency.
 - **No Build Step** — TypeScript executed directly via Bun. Run from source with no compilation needed.
 - **Bun-Powered** — Native TypeScript execution, built-in test runner, and cluster mode for multi-core utilization.
 
@@ -276,12 +277,21 @@ src/
 │       └── public/          Static dashboard assets (JS/CSS/SVG)
 ├── services/                Business logic
 │   ├── accountManager.ts    Account CRUD, round-robin rotation
+│   ├── auth.test.ts         Auth test suite
 │   ├── auth.ts              Auth orchestration
+│   ├── browserlessFetch.ts  Browserless fetch transport
 │   ├── browserProfiles.ts   Browser profile management
+│   ├── bxTokenExtractor.ts  Browserless token extraction
+│   ├── bxUaGenerator.test.ts User-agent generator tests
+│   ├── bxUaGenerator.ts     User-agent generation
+│   ├── configService.test.ts Config service tests
 │   ├── configService.ts     Config loader
 │   ├── defaultSystemPrompt.ts Default system prompt
+│   ├── fireyejsRunner.ts    FireyeJS sandbox runner
+│   ├── logStore.test.ts     Log store tests
 │   ├── logStore.ts          In-memory log store + SSE
 │   ├── loginHelpers.ts      Login helper utilities
+│   ├── loginService.ts      Login orchestration service
 │   ├── modelHealth.ts       Model health tracking
 │   ├── modelRouter.ts       Model routing & fallback
 │   ├── monitorStore.ts      Monitoring data store
@@ -293,6 +303,7 @@ src/
 │   ├── qwenModels.ts        Model fetching & mapping
 │   ├── sessionPool.ts       Session pool with autoscaling
 │   ├── systemLogger.ts      System-wide logger
+│   ├── tokenCache.ts        Token caching layer
 │   └── tokenRefresh.ts      Token refresh logic
 ├── tools/                   Tool calling system
 │   ├── registry.ts          Tool registry
@@ -323,7 +334,7 @@ src/
 bun test
 ```
 
-Uses Bun's built-in test runner. Covers content filtering, tool-call parsing, and streaming sanitization.
+Uses Bun's built-in test runner. Covers content filtering, tool-call parsing, streaming sanitization, bx-ua generation, and config service.
 
 ## Documentation
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -572,7 +572,7 @@ Tool results are intelligently compressed before being sent to the Qwen model. G
 
 ### Session Pooling
 
-Sessions are automatically managed per-account using CloakBrowser browser contexts. The pool rotates across accounts, auto-scales under load, and cleans up idle sessions. No API-level configuration required.
+Sessions are automatically managed per-account using browser session contexts. The pool rotates across accounts, auto-scales under load, and cleans up idle sessions. No API-level configuration required.
 
 ## Support
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,10 +65,10 @@ Qwen Gate is an OpenAI-compatible API proxy that provides access to Qwen AI mode
 │  └────────────────┬─────────────────────────────────────┘  │
 │                   │                                        │
 │  ┌────────────────▼─────────────────────────────────────┐  │
-│  │        Browser Automation Layer (CloakBrowser)        │  │
-│  │  - Browser instance management                       │  │
-│  │  - Qwen chat interface interaction                   │  │
-│  │  - Response extraction                               │  │
+ │  │        Qwen API Transport Layer                       │  │
+ │  │  - Browserless Node.js fetch via wreq-js             │  │
+ │  │  - File upload handling                              │  │
+ │  │  - bx-ua header generation                           │  │
 │  └────────────────┬─────────────────────────────────────┘  │
 │                   │                                        │
 │  ┌────────────────▼─────────────────────────────────────┐  │
@@ -138,26 +138,26 @@ Manages browser sessions and Qwen account rotation.
 - `Session` - Individual browser session
 - `AccountManager` - Account state tracking
 
-### 3. Browser Automation Layer
+### 3. Qwen API Transport
 
-**Location**: `src/services/playwright.ts`
+**Location**: `src/services/` (browserlessFetch.ts, qwen.ts, playwright.ts)
 
-Handles CloakBrowser browser automation for Qwen interaction.
+Dual transport — Node.js fetch via wreq-js for API calls, Playwright only for login/auth/header bootstrap.
 
 **Responsibilities**:
 
-- Browser instance management
-- Qwen chat interface navigation
-- Message sending and response extraction
-- Session authentication
-- Error recovery
+- Pure Node.js HTTP requests to Qwen API via wreq-js session
+- wreq-js provides TLS fingerprinting for bot detection evasion
+- bx-ua generator creates realistic browser UA headers without Playwright
+- Playwright still used for login authentication and initial header extraction
+- File upload handling via qwenFileUpload.ts for large context
 
 **Key Functions**:
 
-- `initPlaywright()` - Start browser instance
-- `createAccountContext()` - Initialize account session context
-- `getQwenHeaders()` - Get authenticated request headers
-- `closePlaywright()` - Shut down and cleanup resources
+- `browserlessFetch()` - Make Qwen API calls via wreq-js
+- `getQwenHeaders()` - Auth headers (from Playwright bootstrap)
+- `fetchQwenModels()` - Model list
+- `closeAll()` - Cleanup sessions
 
 The routes layer handles request dispatch, streaming coordination, content cleanup, and dashboard serving. Route files live directly in `src/routes/` — there is no subdirectory per filter.
 
@@ -212,20 +212,19 @@ The dashboard consists of a routing hub (`dashboardRoutes.ts`), a monitoring pag
    - Check rate limits
    │
    ▼
-4. Browser Automation
-   - Navigate to Qwen chat
-   - Send user message
-   - Wait for response
-   │
-   ▼
+4. Qwen API Transport
+   - Send HTTP request via wreq-js session
+   - Handle file upload if context large
+   - Stream response chunks
+    │
+    ▼
 5. Response Extraction
    - Parse Qwen response
    - Extract text content
    - Detect tool calls
-   │
-   ▼
+    │
+    ▼
 6. Response Pipeline
-   - Echo detection (bidirectional containment)
    - Content filtering
    - Format to OpenAI schema
    │
@@ -282,11 +281,7 @@ The dashboard consists of a routing hub (`dashboardRoutes.ts`), a monitoring pag
    - Processes tool result
    - Generates final response
    │
-   ▼
-7. Echo Detection
-   - Checks if response echoes tool result
-   - Filters verbatim echoes
-   - Returns clean response
+    ▼
 ```
 
 ## Key Subsystems
@@ -395,7 +390,8 @@ Flush Path (full pipeline):
 | **Bun**        | Runtime              | 1.3+    |
 | **TypeScript** | Type safety          | 5.7+    |
 | **Hono**       | Web framework        | Latest  |
-| **CloakBrowser** | Browser automation (wraps Playwright) | Latest  |
+| **wreq-js** | Node.js HTTP with TLS fingerprinting | Latest  |
+| **Playwright** | Login/auth only (not for API) | Latest  |
 | **tsx**        | TypeScript execution | Latest  |
 
 ### Frontend
@@ -415,12 +411,12 @@ Flush Path (full pipeline):
 - Excellent TypeScript support
 - Built-in streaming support
 
-**CloakBrowser**:
+**wreq-js**:
 
-- Wraps Playwright with anti-detection and stealth patches
-- Reliable browser automation with evasion of bot detection
-- Multi-browser support via underlying Playwright engine
-- Active development
+- Lightweight Node.js HTTP client using Rust-native TLS via napi-rs
+- Provides TLS fingerprinting that mimics browser TLS handshakes
+- Per-request sessions to avoid tokio epoll/Bun event loop conflicts
+- Dramatically lower overhead than Playwright for API calls
 
 **TypeScript**:
 
@@ -431,24 +427,22 @@ Flush Path (full pipeline):
 
 ## Design Decisions
 
-### 1. Browser Automation vs. Direct API
+### 1. Dual Transport: Browserless API + Playwright Auth
 
-**Decision**: Use browser automation (CloakBrowser, which wraps Playwright) instead of direct Qwen API.
+**Decision**: Use pure Node.js HTTP via wreq-js for API requests. Playwright is used only for login/authentication.
 
 **Rationale**:
 
 - Qwen doesn't provide a public API
-- Web interface is the only access method
-- Browser automation provides full feature access
-- Can handle authentication and session management
-- CloakBrowser adds anti-detection patches over Playwright for reliable access
+- Earlier approach used full browser automation for everything, but wreq-js provides TLS fingerprinting that avoids bot detection while being much lighter
+- Browser is only needed for login cookies
 
 **Tradeoffs**:
 
-- Higher resource usage (browser instances)
-- More complex error handling
-- Slower than direct API would be
-- Requires browser maintenance
+- Lower resource usage than full browser automation
+- No browser overhead for requests
+- Still need Playwright for auth bootstrap
+- wreq-js sessions must be disposed carefully (tokio epoll fd management)
 
 ### 2. Multi-Account Rotation
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -73,12 +73,21 @@ project-root/
 │   │       └── public/          Static assets (JS/CSS/SVG)
 │   ├── services/                Business logic
 │   │   ├── accountManager.ts    Account CRUD, round-robin
+│   │   ├── auth.test.ts         Auth tests
 │   │   ├── auth.ts              Auth orchestration
 │   │   ├── browserProfiles.ts   Browser profile management
+│   │   ├── browserlessFetch.ts  Browserless TLS/HTTP2 fetch
+│   │   ├── bxUaGenerator.test.ts bx-ua generator tests
+│   │   ├── bxUaGenerator.ts     bx-ua token generation
+│   │   ├── bxTokenExtractor.ts  bx-umidtoken extraction
+│   │   ├── configService.test.ts Config service tests
 │   │   ├── configService.ts     Config loader
 │   │   ├── defaultSystemPrompt.ts Default system prompt
+│   │   ├── fireyejsRunner.ts    Token generation infrastructure
+│   │   ├── logStore.test.ts     Log store tests
 │   │   ├── logStore.ts          In-memory log store + SSE
 │   │   ├── loginHelpers.ts      Login helpers
+│   │   ├── loginService.ts      Login orchestration
 │   │   ├── modelHealth.ts       Model health tracking
 │   │   ├── modelRouter.ts       Model routing & fallback
 │   │   ├── monitorStore.ts      Monitoring data store
@@ -90,6 +99,7 @@ project-root/
 │   │   ├── qwenModels.ts        Model fetching & mapping
 │   │   ├── sessionPool.ts       Session pool with autoscaling
 │   │   ├── systemLogger.ts      System-wide logger
+│   │   ├── tokenCache.ts        Token TTL cache
 │   │   └── tokenRefresh.ts      Token refresh logic
 │   ├── tests/                   Integration tests
 │   │   ├── helpers.ts           Test helpers
@@ -137,7 +147,7 @@ project-root/
 |-----------|---------|
 | `src/routes/` | HTTP route handlers. Each file exports Hono route definitions. |
 | `src/routes/dashboard/` | Dashboard pages and components (template strings, sidebar, routing hub). |
-| `src/services/` | Core business logic: auth, session pool, Playwright, config, logging. |
+| `src/services/` | Core business logic: auth, session pool, Qwen API transport, config, logging. |
 | `src/tools/` | Tool calling system: registry, parser, guard, schema validation. |
 | `src/utils/` | Shared utilities: retry, content filter, token estimator, XML stripping. |
 | `src/types/` | Central TypeScript type definitions. |
@@ -156,11 +166,10 @@ bun dev
 Uses `bun --watch src/index.tsx` to run TypeScript directly with hot reload. The server starts on `http://localhost:26405` (configurable via `PORT`).
 
 The dev command:
-1. Initializes Playwright (chromium by default)
-2. Loads accounts from persistent storage
-3. Pre-warms Qwen auth headers
-4. Starts the Hono HTTP server
-5. Opens the dashboard at `/dashboard`
+1. Loads accounts from persistent storage
+2. Bootstraps Qwen auth headers (via Playwright login if needed)
+3. Starts the Hono HTTP server
+4. Opens the dashboard at `/dashboard`
 
 ### Production Start
 
@@ -187,7 +196,7 @@ bun cluster                # Multi-core cluster mode
 | `PORT` | `26405` | Server port |
 | `HOST` | (empty) | Bind address |
 | `API_KEY` | (empty) | Bearer token for API auth |
-| `BROWSER` | `chromium` | Playwright browser engine |
+| `BROWSER` | `chromium` | Browser engine for login (not API calls) |
 | `STREAMING_MODE` | `auto` | Streaming behavior (`auto`, `true`, `false`) |
 | `SAVE_REQUEST_LOGS` | `false` | Persist request/response logs to disk |
 
@@ -446,7 +455,7 @@ Shared utilities live in `src/utils/`. They are stateless, pure functions or log
 
 ### Session Pool Management
 
-The session pool (`src/services/sessionPool.ts`) manages Playwright browser sessions across Qwen accounts.
+The session pool (`src/services/sessionPool.ts`) manages Qwen account sessions across Qwen accounts.
 
 **Key concepts**:
 


### PR DESCRIPTION
Updates 7 docs to reflect full release history and current architecture.

**Changes:**
- CHANGELOG.md: Add missing releases v0.3.0, v0.3.1, v0.4.0, v0.6.0, v0.7.0
- README.md: Update badges, features (Dual Transport, File Upload), file tree
- docs/ARCHITECTURE.md: Browser Automation Layer -> Qwen API Transport, tech stack, design decisions
- docs/DEVELOPMENT.md: Fix Playwright references, update file tree
- docs/API.md: CloakBrowser -> browser session contexts
- CONTRIBUTING.md, AGENTS.md: Fix file tree descriptions