### PR TITLE
feat: return raw Qwen model data from /v1/models

### DIFF
--- a/src/services/qwenModels.ts
+++ b/src/services/qwenModels.ts
@@ -1,5 +1,3 @@
-import modelSpecs from '../models.json' with { type: 'json' };
-import type { ModelSpec } from '../types/openai.ts';
 import { decrementInFlight, getAllAccountEmails, getTokenWithAccount } from './auth.ts';
 import { browserlessFetch } from './browserlessFetch.ts';
 import { config } from './configService.ts';
@@ -195,30 +193,9 @@ export async function fetchQwenModels(): Promise<any[]> {
         return cachedModels || [];
       }
 
-      const models = json.data.map((m: any) => {
-        const id = (m.id as string).toLowerCase().replace(/\./g, '-');
-        const typedSpecs = modelSpecs as Record<string, ModelSpec>;
-        const specs = typedSpecs[id] ||
-          typedSpecs[id.replace(/-no-thinking$/, '')] || { max_context: 1000000, max_output: 65536, modalities: ['text'] };
-        return {
-          id: m.id,
-          object: 'model',
-          created: m.info?.created_at || Math.floor(Date.now() / 1000),
-          owned_by: m.owned_by || 'qwen',
-          context_window: specs.max_context,
-          max_output_tokens: specs.max_output,
-          modalities: specs.modalities,
-        };
-      });
-
-      const extendedModels = [...models];
-      for (const m of models) {
-        extendedModels.push({ ...m, id: `${m.id}-no-thinking` });
-      }
-
-      cachedModels = extendedModels;
+      cachedModels = json.data;
       lastModelsFetch = now;
-      return extendedModels;
+      return json.data;
     } catch (err: any) {
       lastErr = err;
     }

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -21,7 +21,7 @@ test('Health check returns degraded when Playwright not initialized', async () =
   assert.ok(typeof body.uptime === 'number');
 });
 
-test('Models endpoint returns qwen3.6-plus and qwen3.6-plus-no-thinking', async () => {
+test('Models endpoint returns raw Qwen model data', async () => {
   const originalFetch = globalThis.fetch;
   (globalThis as any).fetch = async (input: any) => {
     const url = typeof input === 'string' ? input : input.url;
@@ -41,7 +41,6 @@ test('Models endpoint returns qwen3.6-plus and qwen3.6-plus-no-thinking', async 
     assert.strictEqual(body.object, 'list');
     assert.ok(Array.isArray(body.data));
     assert.ok(body.data.some((m: any) => m.id === 'qwen3.6-plus'));
-    assert.ok(body.data.some((m: any) => m.id === 'qwen3.6-plus-no-thinking'));
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
 now passes through Qwen's raw API response instead of our custom-mapped/enriched list. Removes models.json dependency and -no-thinking doubling from the endpoint (chat routing still handles -no-thinking internally).