### PR TITLE
fix: add auth token cookie to v1/models request

### DIFF
--- a/src/services/qwenModels.ts
+++ b/src/services/qwenModels.ts
@@ -169,6 +169,9 @@ export async function fetchQwenModels(): Promise<any[]> {
   const { email: resolvedEmail } = await getBasicHeaders();
   if (resolvedEmail) decrementInFlight(resolvedEmail);
 
+  const tokenInfo = resolvedEmail ? await getTokenWithAccount(resolvedEmail) : null;
+  const cookieStr = tokenInfo ? `token=${tokenInfo.token}` : '';
+
   let lastErr: Error | null = null;
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
@@ -181,6 +184,7 @@ export async function fetchQwenModels(): Promise<any[]> {
           source: 'web',
           origin: QWEN_API_BASE,
           referer: 'https://chat.qwen.ai/',
+          ...(cookieStr ? { cookie: cookieStr } : {}),
         },
         accountEmail: resolvedEmail,
       });


### PR DESCRIPTION
Qwen API requires the auth token cookie to return the full model list. Without it, only a default/limited set appears. Matches the pattern used by deleteAllChats and postQwenSettings.