### PR TITLE
feat: upload images in messages to Qwen file system via STS/OSS

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -6,7 +6,7 @@ import { logStore } from '../services/logStore.ts';
 import { modelRouter } from '../services/modelRouter.ts';
 import { RetryableQwenStreamError } from '../services/qwen.ts';
 import type { QwenFileAttachment } from '../services/qwenFileUpload.ts';
-import { uploadLargeTextAsFile } from '../services/qwenFileUpload.ts';
+import { uploadImageAsFile, uploadLargeTextAsFile } from '../services/qwenFileUpload.ts';
 import { sessionPool } from '../services/sessionPool.ts';
 import { cleanTextOfXmlArtifacts } from '../tools/xmlToolParser.ts';
 import { OpenAIRequest } from '../types/openai.ts';
@@ -88,11 +88,37 @@ async function parseRequestBody(c: Context) {
 }
 
 async function setupSession(messages: any[], body: OpenAIRequest, availableTokens: number, toolCalling: boolean, logId: string) {
+  // ── Image detection ──────────────────────────────────────────
+  // Scan messages for image_url parts — upload happens inside retry loop with account email
+  let hasImages = false;
+  const imageUrls: string[] = [];
+
+  for (const msg of messages) {
+    if (!Array.isArray(msg.content)) continue;
+    for (const part of msg.content) {
+      if (part?.type === 'image_url' && part?.image_url?.url) {
+        hasImages = true;
+        imageUrls.push(part.image_url.url);
+      }
+    }
+  }
+
+  // Strip image_url parts from messages (keep only text parts)
+  // so buildQwenMessages doesn't serialize them as JSON text
+  let cleanedMessages = messages;
+  if (hasImages) {
+    cleanedMessages = messages.map((msg: any) => {
+      if (!Array.isArray(msg.content)) return msg;
+      const textParts = msg.content.filter((c: any) => c.type !== 'image_url');
+      return { ...msg, content: textParts.length > 0 ? textParts : [{ type: 'text', text: '[Image]' }] };
+    });
+  }
+
   const {
     qwenMessages: processedMessages,
     systemContent,
     toolResultsContent,
-  } = buildQwenMessages(messages, body, availableTokens, toolCalling);
+  } = buildQwenMessages(cleanedMessages, body, availableTokens, toolCalling);
 
   // File upload happens inside retry loop using the same account as the request
   // (accounts can't access files uploaded by other accounts — must share the account)
@@ -110,6 +136,23 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
       throw lastError || new Error('All accounts are rate-limited. Please wait and try again later.');
     }
 
+    // Upload all images in parallel
+    let imageFiles: QwenFileAttachment[] = [];
+    if (hasImages && accountEmail) {
+      const results = await Promise.all(
+        imageUrls.map((url) =>
+          uploadImageAsFile(accountEmail, url).catch((err: any) => {
+            logStore.log('warn', 'chat', `[Chat] Image upload failed: ${err.message}`);
+            return null;
+          }),
+        ),
+      );
+      imageFiles = results.filter((f): f is QwenFileAttachment => f !== null);
+      if (imageFiles.length === 0) {
+        throw new Error('Failed to upload images — none of the image files could be uploaded');
+      }
+    }
+
     // Upload a single context file containing system instructions + tool results
     // Merging cuts upload overhead in half (one STS token, one OSS upload, one parse poll)
     if (accountEmail && (systemContent || toolResultsContent)) {
@@ -123,6 +166,24 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
       } catch (err: any) {
         logStore.log('debug', 'chat', '[Chat] Failed to upload context file: ' + (err.message || err));
       }
+    }
+
+    // Attach uploaded images to the first message
+    if (imageFiles.length > 0) {
+      processedMessages[0] = {
+        ...processedMessages[0],
+        files: [...(processedMessages[0].files || []), ...imageFiles],
+      };
+    }
+
+    // Switch to vision chat type when images are present
+    if (hasImages && imageFiles.length > 0) {
+      processedMessages[0] = {
+        ...processedMessages[0],
+        chat_type: 't2v',
+        sub_chat_type: 't2v',
+        extra: { meta: { subChatType: 't2v' } },
+      };
     }
 
     let sessionResult;

--- a/src/services/qwenFileUpload.ts
+++ b/src/services/qwenFileUpload.ts
@@ -260,13 +260,61 @@ async function pollParseStatus(email: string, fileId: string, maxWaitMs = 5_000)
   // Qwen will include the file content once parsing completes on its side.
 }
 
+// --- Shared internal: upload arbitrary file content ---
+
+/**
+ * Upload arbitrary content (buffer) as a file to Qwen's file system.
+ * Runs the full 4-step pipeline: STS token -> OSS upload -> parse trigger -> poll status.
+ */
+async function uploadFileContent(
+  email: string,
+  buffer: Buffer,
+  fileName: string,
+  contentType: string,
+  fileClass: string,
+  showType: string,
+): Promise<QwenFileAttachment> {
+  const fileSize = buffer.length;
+
+  logStore.log('debug', 'upload', `[FileUpload] Uploading ${fileSize} bytes as "${fileName}" (${contentType}) for ${email}`);
+
+  // Step 1: Get STS credentials
+  const sts = await getstsToken(email, fileName, fileSize);
+  logStore.log(
+    'debug',
+    'upload',
+    `[FileUpload] Got STS token — bucket=${sts.bucketname}, file_id=${sts.file_id}, file_url=${sts.file_url}, endpoint=${sts.endpoint}, file_path=${sts.file_path}`,
+  );
+
+  // Step 2: Upload to OSS
+  const fileUrl = await uploadToOss(sts, buffer, contentType);
+  logStore.log('debug', 'upload', `[FileUpload] Uploaded to OSS — url=${fileUrl.substring(0, 80)}...`);
+
+  // Step 3: Trigger parsing
+  await parseFile(email, sts.file_id);
+  logStore.log('debug', 'upload', `[FileUpload] Parse triggered for ${sts.file_id}`);
+
+  // Step 4: Poll until parsed
+  await pollParseStatus(email, sts.file_id);
+  logStore.log('debug', 'upload', `[FileUpload] Parse complete for ${sts.file_id}`);
+
+  return buildQwenFileAttachment(sts, fileName, fileSize, contentType, fileClass, showType);
+}
+
 // --- Orchestrator: upload large text as a Qwen file attachment ---
 
 /**
  * Build the exact file attachment object matching Qwen web UI format.
  * Extracts user_id from file_path (format: "<user_id>/<file_id>_<filename>").
  */
-function buildQwenFileAttachment(sts: StsTokenResponse, fileName: string, fileSize: number, contentType: string): QwenFileAttachment {
+function buildQwenFileAttachment(
+  sts: StsTokenResponse,
+  fileName: string,
+  fileSize: number,
+  contentType: string,
+  fileClass: string,
+  showType: string,
+): QwenFileAttachment {
   // Extract user_id from file_path: "5309db52-.../370e7cdc-..._filename" → first segment
   const userId = sts.file_path.split('/')[0] || '';
   const now = Date.now();
@@ -304,8 +352,8 @@ function buildQwenFileAttachment(sts: StsTokenResponse, fileName: string, fileSi
     error: '',
     itemId: crypto.randomUUID(),
     file_type: contentType,
-    showType: 'file',
-    file_class: 'document',
+    showType,
+    file_class: fileClass,
     uploadTaskId: crypto.randomUUID(),
   };
 }
@@ -313,30 +361,48 @@ function buildQwenFileAttachment(sts: StsTokenResponse, fileName: string, fileSi
 export async function uploadLargeTextAsFile(email: string, text: string, fileName: string): Promise<QwenFileAttachment> {
   const encoder = new TextEncoder();
   const content = encoder.encode(text);
-  const fileSize = content.length;
   const contentType = 'text/plain';
+  return uploadFileContent(email, Buffer.from(content), fileName, contentType, 'document', 'file');
+}
 
-  logStore.log('debug', 'upload', `[FileUpload] Uploading ${fileSize} bytes (${text.length} chars) as "${fileName}" for ${email}`);
+/**
+ * Download an image (data URI or remote URL) and upload it to Qwen's file system.
+ * Returns a QwenFileAttachment ready to attach to messages.
+ */
+export async function uploadImageAsFile(email: string, imageUrl: string): Promise<QwenFileAttachment> {
+  let buffer: Buffer;
+  let mimeType: string;
+  let fileName: string;
 
-  // Step 1: Get STS credentials
-  const sts = await getstsToken(email, fileName, fileSize);
-  logStore.log(
-    'debug',
-    'upload',
-    `[FileUpload] Got STS token — bucket=${sts.bucketname}, file_id=${sts.file_id}, file_url=${sts.file_url}, endpoint=${sts.endpoint}, file_path=${sts.file_path}`,
-  );
+  if (imageUrl.startsWith('data:')) {
+    // Data URI: data:image/png;base64,iVBOR...
+    const match = imageUrl.match(/^data:([^;]+);base64,(.+)$/);
+    if (!match) throw new Error('Invalid data URI format');
+    mimeType = match[1];
+    buffer = Buffer.from(match[2], 'base64');
+    fileName = `image.${mimeType.split('/')[1] || 'png'}`;
+  } else {
+    // Remote URL — fetch with timeout
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 30_000);
+    try {
+      const response = await fetch(imageUrl, { signal: controller.signal });
+      if (!response.ok) throw new Error(`Failed to download image: ${response.status}`);
+      const contentType = response.headers.get('content-type') || '';
+      if (!contentType.startsWith('image/')) throw new Error(`Not an image: ${contentType}`);
+      const arrayBuffer = await response.arrayBuffer();
+      buffer = Buffer.from(arrayBuffer);
+      mimeType = contentType;
+      fileName = `image.${mimeType.split('/')[1] || 'png'}`;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
 
-  // Step 2: Upload to OSS
-  const fileUrl = await uploadToOss(sts, Buffer.from(content), contentType);
-  logStore.log('debug', 'upload', `[FileUpload] Uploaded to OSS — url=${fileUrl.substring(0, 80)}...`);
+  // Reject images over 10MB
+  if (buffer.length > 10 * 1024 * 1024) {
+    throw new Error(`Image too large: ${(buffer.length / 1024 / 1024).toFixed(1)}MB (max 10MB)`);
+  }
 
-  // Step 3: Trigger parsing
-  await parseFile(email, sts.file_id);
-  logStore.log('debug', 'upload', `[FileUpload] Parse triggered for ${sts.file_id}`);
-
-  // Step 4: Poll until parsed
-  await pollParseStatus(email, sts.file_id);
-  logStore.log('debug', 'upload', `[FileUpload] Parse complete for ${sts.file_id}`);
-
-  return buildQwenFileAttachment(sts, fileName, fileSize, contentType);
+  return uploadFileContent(email, buffer, fileName, mimeType, 'image', 'image');
 }

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -6,6 +6,7 @@ process.env.TEST_MOCK_PLAYWRIGHT = 'true';
 process.env.API_KEY = 'test-key-for-testing';
 
 import { app } from '../index.tsx';
+import { accounts } from '../services/accountManager.ts';
 
 const TEST_API_KEY = 'test-key-for-testing';
 const authHeaders = { Authorization: `Bearer ${TEST_API_KEY}` };
@@ -254,6 +255,7 @@ test('Chat Completions returns a JSON chat.completion object for non-streaming r
 test('API Key protection', async () => {
   const originalApiKey = process.env.API_KEY;
   process.env.API_KEY = 'test-api-key';
+  let originalFetch: any;
 
   try {
     // 1. Test request without API Key
@@ -270,7 +272,7 @@ test('API Key protection', async () => {
 
     // 3. Test request with correct API Key
     // Mock fetch for models list
-    const originalFetch = globalThis.fetch;
+    originalFetch = globalThis.fetch;
     (globalThis as any).fetch = async () => new Response(JSON.stringify({ data: [] }), { status: 200 });
 
     try {
@@ -283,7 +285,143 @@ test('API Key protection', async () => {
       globalThis.fetch = originalFetch;
     }
   } finally {
+    globalThis.fetch = originalFetch;
     process.env.API_KEY = originalApiKey;
+  }
+});
+
+test('Chat completions with image uploads attaches files and sets t2v chat_type', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalAccounts = [...accounts];
+
+  // Seed a test account so pickAccount returns an account for image upload
+  accounts.push({
+    email: 'test@qwen-gate.dev',
+    password: 'test',
+    state: { token: 'mock-token', expiresAt: Date.now() + 3600000, refreshToken: null },
+    lastUsed: 0,
+    throttledUntil: 0,
+    refreshInFlight: null,
+    loginAttempt: 0,
+    inFlight: 0,
+    totalRequests: 0,
+    startupStatus: 'ready',
+  });
+
+  let stsCalled = false;
+  let ossCalled = false;
+  let chatPayload: any = null;
+
+  (globalThis as any).fetch = async (input: any, init?: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('/api/models')) {
+      return new Response(JSON.stringify({ data: [{ id: 'qwen3.6-plus', owned_by: 'qwen' }] }), { status: 200 });
+    }
+    if (url.includes('/api/v2/files/getstsToken')) {
+      stsCalled = true;
+      return new Response(
+        JSON.stringify({
+          data: {
+            access_key_id: 'test-key',
+            access_key_secret: 'test-secret',
+            security_token: 'test-token',
+            bucketname: 'test-bucket',
+            region: 'oss-cn-hangzhou',
+            endpoint: 'oss-cn-hangzhou.aliyuncs.com',
+            file_id: 'test-file-id',
+            file_path: 'test-user/test-file-id_image.png',
+            file_url: 'https://test-bucket.oss-cn-hangzhou.aliyuncs.com/test-file-id_image.png',
+          },
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.includes('/api/v2/files/parse/status')) {
+      return new Response(JSON.stringify({ data: [{ status: 'success' }] }), { status: 200 });
+    }
+    if (url.includes('/api/v2/files/parse')) {
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    }
+    if (url.includes('aliyuncs.com') || url.includes('oss-')) {
+      ossCalled = true;
+      return new Response(null, { status: 200 });
+    }
+    if (url.includes('/api/v2/chat/completions')) {
+      // Capture the payload for later assertions
+      // init?.body is set when browserlessFetch calls globalThis.fetch(url, { method, headers, body })
+      const bodyStr =
+        typeof input === 'string' && init?.body ? init.body : typeof input !== 'string' ? await (input as Request).clone().text() : '';
+      try {
+        chatPayload = JSON.parse(bodyStr);
+      } catch {}
+      // Return a simple stream
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('data: {"choices": [{"delta": {"content": "Image received"}}]}\n\n'));
+          c.enqueue(new TextEncoder().encode('data: [DONE]\n\n'));
+          c.close();
+        },
+      });
+      return new Response(stream, { status: 200 });
+    }
+    return originalFetch(input, init);
+  };
+
+  try {
+    const payload = {
+      model: 'qwen3.6-plus',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'What is in this image?' },
+            { type: 'image_url', image_url: { url: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAA=' } },
+          ],
+        },
+      ],
+      stream: false,
+    };
+
+    const req = new Request('http://localhost/v1/chat/completions', {
+      method: 'POST',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, { Authorization: 'Bearer test-key-for-testing' }),
+      body: JSON.stringify(payload),
+    });
+
+    const res = await app.fetch(req);
+    assert.strictEqual(res.status, 200);
+
+    // Verify STS token was requested (image upload initiated)
+    assert.ok(stsCalled, 'Should have called getstsToken for image upload');
+
+    // Verify OSS upload happened
+    assert.ok(ossCalled, 'Should have uploaded image to OSS');
+
+    // Verify the chat payload has the right format
+    assert.ok(chatPayload, 'Chat completion should have been called');
+    const msg = chatPayload?.messages?.[0];
+    assert.ok(msg, 'Should have at least one message');
+
+    // The image_url should be stripped from content text (only text parts remain)
+    assert.ok(!msg.content.includes('image_url'), 'Image URL should be stripped from content text');
+    assert.ok(msg.content.includes('What is in this image?'), 'Text content should be preserved');
+
+    // Should have files attached
+    assert.ok(Array.isArray(msg.files), 'Message should have files array');
+    assert.ok(msg.files.length > 0, 'Should have at least one file (image)');
+
+    // Chat type should be t2v for vision
+    assert.strictEqual(msg.chat_type, 't2v', 'Chat type should be t2v for images');
+    assert.strictEqual(msg.sub_chat_type, 't2v', 'Sub chat type should be t2v');
+    assert.strictEqual(msg.extra?.meta?.subChatType, 't2v', 'Extra subChatType should be t2v');
+
+    // Verify file attachment format
+    const file = msg.files[0];
+    assert.strictEqual(file.type, 'file', 'File attachment type should be file');
+    assert.strictEqual(file.file_class, 'image', 'File class should be image');
+  } finally {
+    globalThis.fetch = originalFetch;
+    accounts.splice(0, accounts.length, ...originalAccounts);
   }
 });
 


### PR DESCRIPTION
OpenAI messages with image_url parts now get their images uploaded to Qwen's file system instead of being serialized as JSON text and lost.

**Changes:**
- `qwenFileUpload.ts`: Extracted shared `uploadFileContent()` pipeline, added `uploadImageAsFile()` supporting data URIs and remote URLs (10MB limit, 30s timeout)
- `chat.ts` setupSession(): Detects image_url parts, strips them from content, uploads images in parallel, attaches as QwenFileAttachment, sets chat_type to t2v
- 113/113 tests pass

**Details:**
- Images are uploaded via Qwen's existing STS/OSS pipeline (same as context.txt)
- Single bad URL won't crash the batch — individual upload catches
- Zero successful uploads throws an error, triggering the account retry loop
- Image-only messages produce a text placeholder instead of garbled JSON
- chat_type, sub_chat_type, and extra.meta.subChatType all set to t2v