### PR TITLE
feat: split inline context at 50k, push older history to context.txt as chat_history

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -120,6 +120,39 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
     toolResultsContent,
   } = buildQwenMessages(cleanedMessages, body, availableTokens, toolCalling);
 
+  // ── Inline content truncation ─────────────────────────────────
+  // Keep the most recent ~50k characters inline; push older history
+  // into context.txt so the model can reference it when needed.
+  const MAX_INLINE_CHARS = 50000;
+  let inlineContent = processedMessages[0].content as string;
+  let chatHistoryContent = '';
+
+  if (typeof inlineContent === 'string' && inlineContent.length > MAX_INLINE_CHARS) {
+    // Split on message boundaries: \n\n followed by <user> or <assist>
+    const parts = inlineContent.split(/\n\n(?=<user>|<assist>)/);
+
+    // Walk backwards — keep as many recent segments as fit within limit
+    let keptLen = 0;
+    let splitIdx = parts.length;
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const addLen = parts[i].length + (keptLen > 0 ? 2 : 0);
+      if (keptLen + addLen <= MAX_INLINE_CHARS) {
+        keptLen += addLen;
+        splitIdx = i;
+      } else {
+        break;
+      }
+    }
+
+    // ponytail: simple character-based split at message boundaries.
+    // If models need more precise token-aware splitting, add later.
+    if (splitIdx > 0) {
+      chatHistoryContent = parts.slice(0, splitIdx).join('\n\n');
+      inlineContent = parts.slice(splitIdx).join('\n\n');
+      processedMessages[0] = { ...processedMessages[0], content: inlineContent };
+    }
+  }
+
   // File upload happens inside retry loop using the same account as the request
   // (accounts can't access files uploaded by other accounts — must share the account)
   let lastFailedEmail: string | undefined;
@@ -153,12 +186,13 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
       }
     }
 
-    // Upload a single context file containing system instructions + tool results
+    // Upload a single context file: system instructions + tool results + older chat history
     // Merging cuts upload overhead in half (one STS token, one OSS upload, one parse poll)
-    if (accountEmail && (systemContent || toolResultsContent)) {
+    if (accountEmail && (systemContent || toolResultsContent || chatHistoryContent)) {
       const parts: string[] = [];
       if (systemContent) parts.push(`<system-instructions>\n${systemContent}\n</system-instructions>`);
       if (toolResultsContent) parts.push(`<tool-results>\n${toolResultsContent}\n</tool-results>`);
+      if (chatHistoryContent) parts.push(`<chat_history>\n${chatHistoryContent}\n</chat_history>`);
       const combinedContent = parts.join('\n\n');
       try {
         const file = await uploadLargeTextAsFile(accountEmail, combinedContent, 'context.txt');

--- a/src/services/defaultSystemPrompt.ts
+++ b/src/services/defaultSystemPrompt.ts
@@ -21,7 +21,7 @@ Your conversation uses tagged message blocks. Each message is wrapped in XML-lik
 
 Messages may include attached files. These are referenced inline and also appear as file objects in the message.
 
-- **\`context.txt\` file** — A single file combining system instructions and tool call results. It contains two tagged sections:
+- **\`context.txt\` file** — A single file combining system instructions, tool call results, and older conversation history. It contains tagged sections:
 
   \`\`\`
   <system-instructions>
@@ -31,6 +31,10 @@ Messages may include attached files. These are referenced inline and also appear
   <tool-results>
   ... results of your tool calls ...
   </tool-results>
+
+  <chat_history>
+  ... older conversation history (beyond the inline context window) ...
+  </chat_history>
   \`\`\`
 
 ### How to Use \`context.txt\`
@@ -42,6 +46,7 @@ Messages may include attached files. These are referenced inline and also appear
 2. The **latest entries** at the end correspond to the most recent tool calls. Always start from the bottom.
 3. Do not guess or assume what a tool returned — read the file.
 4. If there are multiple tool calls, all their results are appended sequentially in the order they were called.
+5. If the \`<chat_history>\` section exists, it contains older conversation turns that preceded the inline context. Read it if you need the full conversation history.
 
 When a file is attached, treat it as authoritative context for that turn.
 `.trim();


### PR DESCRIPTION
When conversation content exceeds 50k characters, the oldest segments are moved into context.txt under a <chat_history> tag. The most recent ~50k stays inline so the model always has immediate context. The model can read the context.txt file for older conversation history when needed.