### PR TITLE
fix: align image attachment format with Qwen web UI exactly

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -210,16 +210,6 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
       };
     }
 
-    // Switch to vision chat type when images are present
-    if (hasImages && imageFiles.length > 0) {
-      processedMessages[0] = {
-        ...processedMessages[0],
-        chat_type: 't2v',
-        sub_chat_type: 't2v',
-        extra: { meta: { subChatType: 't2v' } },
-      };
-    }
-
     let sessionResult;
     try {
       sessionResult = await acquireSessionWithCorrections(accountEmail, processedMessages);

--- a/src/services/qwenFileUpload.ts
+++ b/src/services/qwenFileUpload.ts
@@ -30,7 +30,7 @@ interface StsTokenResponse {
  * The web UI sends this complex nested object in messages[].files[].
  */
 export interface QwenFileAttachment {
-  type: 'file';
+  type: string;
   file: {
     created_at: number;
     data: Record<string, unknown>;
@@ -42,7 +42,7 @@ export interface QwenFileAttachment {
       name: string;
       size: number;
       content_type: string;
-      parse_meta: { parse_status: string };
+      parse_meta?: { parse_status: string };
     };
     update_at: number;
     lastModified: number;
@@ -274,6 +274,7 @@ async function uploadFileContent(
   fileClass: string,
   showType: string,
   filetype: string = 'file',
+  attachmentType: string = 'file',
 ): Promise<QwenFileAttachment> {
   const fileSize = buffer.length;
 
@@ -291,15 +292,18 @@ async function uploadFileContent(
   const fileUrl = await uploadToOss(sts, buffer, contentType);
   logStore.log('debug', 'upload', `[FileUpload] Uploaded to OSS — url=${fileUrl.substring(0, 80)}...`);
 
-  // Step 3: Trigger parsing
-  await parseFile(email, sts.file_id);
-  logStore.log('debug', 'upload', `[FileUpload] Parse triggered for ${sts.file_id}`);
+  // Images don't need server-side parsing — Qwen processes them directly from OSS
+  if (attachmentType === 'file') {
+    // Step 3: Trigger parsing
+    await parseFile(email, sts.file_id);
+    logStore.log('debug', 'upload', `[FileUpload] Parse triggered for ${sts.file_id}`);
 
-  // Step 4: Poll until parsed
-  await pollParseStatus(email, sts.file_id);
-  logStore.log('debug', 'upload', `[FileUpload] Parse complete for ${sts.file_id}`);
+    // Step 4: Poll until parsed
+    await pollParseStatus(email, sts.file_id);
+    logStore.log('debug', 'upload', `[FileUpload] Parse complete for ${sts.file_id}`);
+  }
 
-  return buildQwenFileAttachment(sts, fileName, fileSize, contentType, fileClass, showType);
+  return buildQwenFileAttachment(sts, fileName, fileSize, contentType, fileClass, showType, attachmentType);
 }
 
 // --- Orchestrator: upload large text as a Qwen file attachment ---
@@ -315,13 +319,21 @@ function buildQwenFileAttachment(
   contentType: string,
   fileClass: string,
   showType: string,
+  attachmentType: string = 'file',
 ): QwenFileAttachment {
   // Extract user_id from file_path: "5309db52-.../370e7cdc-..._filename" → first segment
   const userId = sts.file_path.split('/')[0] || '';
   const now = Date.now();
 
+  const meta: QwenFileAttachment['file']['meta'] = {
+    name: fileName,
+    size: fileSize,
+    content_type: contentType,
+    ...(attachmentType === 'file' ? { parse_meta: { parse_status: 'success' as const } } : {}),
+  };
+
   return {
-    type: 'file',
+    type: attachmentType,
     file: {
       created_at: now,
       data: {},
@@ -329,12 +341,7 @@ function buildQwenFileAttachment(
       hash: null,
       id: sts.file_id,
       user_id: userId,
-      meta: {
-        name: fileName,
-        size: fileSize,
-        content_type: contentType,
-        parse_meta: { parse_status: 'success' },
-      },
+      meta,
       update_at: now,
       lastModified: now,
       name: fileName,
@@ -405,5 +412,5 @@ export async function uploadImageAsFile(email: string, imageUrl: string): Promis
     throw new Error(`Image too large: ${(buffer.length / 1024 / 1024).toFixed(1)}MB (max 10MB)`);
   }
 
-  return uploadFileContent(email, buffer, fileName, mimeType, 'image', 'image', 'image');
+  return uploadFileContent(email, buffer, fileName, mimeType, 'vision', 'image', 'image', 'image');
 }

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -290,7 +290,7 @@ test('API Key protection', async () => {
   }
 });
 
-test('Chat completions with image uploads attaches files and sets t2v chat_type', async () => {
+test('Chat completions with image uploads attaches files (t2t chat_type, vision class)', async () => {
   const originalFetch = globalThis.fetch;
   const originalAccounts = [...accounts];
 
@@ -410,15 +410,15 @@ test('Chat completions with image uploads attaches files and sets t2v chat_type'
     assert.ok(Array.isArray(msg.files), 'Message should have files array');
     assert.ok(msg.files.length > 0, 'Should have at least one file (image)');
 
-    // Chat type should be t2v for vision
-    assert.strictEqual(msg.chat_type, 't2v', 'Chat type should be t2v for images');
-    assert.strictEqual(msg.sub_chat_type, 't2v', 'Sub chat type should be t2v');
-    assert.strictEqual(msg.extra?.meta?.subChatType, 't2v', 'Extra subChatType should be t2v');
+    // Chat type should remain t2t (default) — Qwen web UI uses t2t even with images
+    assert.strictEqual(msg.chat_type, 't2t', 'Chat type should remain t2t for images');
+    assert.strictEqual(msg.sub_chat_type, 't2t', 'Sub chat type should remain t2t');
+    assert.strictEqual(msg.extra?.meta?.subChatType, 't2t', 'Extra subChatType should remain t2t');
 
     // Verify file attachment format
     const file = msg.files[0];
-    assert.strictEqual(file.type, 'file', 'File attachment type should be file');
-    assert.strictEqual(file.file_class, 'image', 'File class should be image');
+    assert.strictEqual(file.type, 'image', 'File attachment type should be image');
+    assert.strictEqual(file.file_class, 'vision', 'File class should be vision');
   } finally {
     globalThis.fetch = originalFetch;
     accounts.splice(0, accounts.length, ...originalAccounts);


### PR DESCRIPTION
Captured real Qwen web UI image upload via Chrome DevTools. Found 4 mismatches between our implementation and what Qwen actually expects:

1. **type**: was `"file"` — must be `"image"`
2. **file_class**: was `"image"` — must be `"vision"`
3. **parse_meta**: was included — Qwen does not include this for images
4. **parse/poll steps**: we called parseFile + pollParseStatus — Qwen skips these for images
5. **chat_type**: we set `t2v` — Qwen uses `t2t` even with images (reverted)