### PR TITLE
fix: vision fallback model qwen3.6-plus to qwen3.7-plus

### DIFF
--- a/src/routes/chatHelpers.ts
+++ b/src/routes/chatHelpers.ts
@@ -224,7 +224,7 @@ export function handleImageModelFallback(body: any, messages: any[]): void {
     const supportsImages = specs?.modalities.includes('image');
     if (!supportsImages) {
       const original = body.model;
-      body.model = 'qwen3.6-plus' + (original.includes('-no-thinking') ? '-no-thinking' : '');
+      body.model = 'qwen3.7-plus' + (original.includes('-no-thinking') ? '-no-thinking' : '');
     }
   }
 }


### PR DESCRIPTION
When a non-vision model receives an image, handleImageModelFallback now switches to qwen3.7-plus instead of the older qwen3.6-plus.