### PR TITLE
fix: parallel image uploads with concurrency limit of 2

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -170,17 +170,22 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
       throw lastError || new Error('All accounts are rate-limited. Please wait and try again later.');
     }
 
-    // Upload images sequentially to avoid wreq-js tokio/Bun epoll conflicts
-    // (parallel wreq-js sessions share a tokio runtime that interferes with Bun's event loop)
+    // Upload images with concurrency limit to avoid wreq-js tokio/Bun epoll conflicts
+    // (too many concurrent wreq-js sessions can corrupt the shared Rust tokio runtime)
     let imageFiles: QwenFileAttachment[] = [];
     if (hasImages && accountEmail) {
-      for (const url of imageUrls) {
-        try {
-          const file = await uploadImageAsFile(accountEmail, url);
-          if (file) imageFiles.push(file);
-        } catch (err: any) {
-          logStore.log('warn', 'chat', `[Chat] Image upload failed: ${err.message}`);
-        }
+      const MAX_CONCURRENT = 2;
+      for (let i = 0; i < imageUrls.length; i += MAX_CONCURRENT) {
+        const batch = imageUrls.slice(i, i + MAX_CONCURRENT);
+        const results = await Promise.all(
+          batch.map((url) =>
+            uploadImageAsFile(accountEmail, url).catch((err: any) => {
+              logStore.log('warn', 'chat', `[Chat] Image upload failed: ${err.message}`);
+              return null;
+            }),
+          ),
+        );
+        imageFiles.push(...results.filter((f): f is QwenFileAttachment => f !== null));
       }
       if (imageFiles.length === 0) {
         throw new Error('Failed to upload images — none of the image files could be uploaded');


### PR DESCRIPTION
Reverts sequential uploads to parallel with concurrency limit (2). Sequential was too slow for multiple images. Unlimited parallel was crashing wreq-js tokio runtime. Limit of 2 gives speedup while avoiding the epoll fd conflict.