### PR TITLE
feat: replace wreq-js with cycletls (Go-based TLS fingerprinting)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,11 +7,11 @@
       "dependencies": {
         "@hono/node-server": "^2.0.3",
         "cloakbrowser": "^0.4.2",
+        "cycletls": "^2.0.5",
         "dotenv": "^16.6.1",
         "hono": "^4.12.21",
         "playwright": "^1.60.0",
         "playwright-core": "^1.61.0",
-        "wreq-js": "^2.3.1",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -232,13 +232,33 @@
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "cloakbrowser": ["cloakbrowser@0.4.2", "", { "dependencies": { "tar": "^7.0.0" }, "peerDependencies": { "mmdb-lib": ">=2.0.0", "playwright-core": ">=1.53.0", "puppeteer-core": ">=21.0.0", "socks-proxy-agent": ">=10.0.0" }, "optionalPeers": ["mmdb-lib", "playwright-core", "puppeteer-core", "socks-proxy-agent"], "bin": { "cloakbrowser": "dist/cli.js" } }, "sha512-PwXXx3L4pIFuGJtRD00eWb67HxylLEDeAAvINp//s5abcb5gACnvmzSGCzS4/5bUSSNKSJIfnPKprP3VFNJIeQ=="],
 
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "cycletls": ["cycletls@2.0.5", "", { "dependencies": { "@types/node": "^20.14.0", "form-data": "^4.0.0", "ws": "^8.17.0" } }, "sha512-Nud94JBPZu1JTXWJ1GpIoQNR1xxU84WYt7G0dxzwpUe1xAAs6YbihvlQhIhPv9xljjonINJfWPFaeb8Ex1wLhQ=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": "bin/esbuild" }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
@@ -246,17 +266,39 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
+
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "hono": ["hono@4.12.21", "", {}, "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "knip": ["knip@6.17.1", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "oxc-parser": "^0.135.0", "oxc-resolver": "^11.20.0", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.1", "yaml": "^2.9.0", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-HcQsZSQ4Ymhuay4BVzJtM5pFZNDSomYYqcNCZOSITPQh9g18a09DqziWAxSt2G+BH9wGlG+0ZjWpEnaFlnKseQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
@@ -296,7 +338,7 @@
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
-    "wreq-js": ["wreq-js@2.3.1", "", { "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ] }, "sha512-vaKasaKeskrDKEuuO5Q5uamEG9a6FrF5ZSicH7TCvYS4RxF7/gzaU/vYqwJzcs+uydyJPVWY1KCvfVCgp0tiGA=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
@@ -304,8 +346,12 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
+    "cycletls/@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
+
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "playwright/playwright-core": ["playwright-core@1.60.0", "", { "bin": "cli.js" }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
+    "cycletls/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,11 +56,11 @@
   "dependencies": {
     "@hono/node-server": "^2.0.3",
     "cloakbrowser": "^0.4.2",
+    "cycletls": "^2.0.5",
     "dotenv": "^16.6.1",
     "hono": "^4.12.21",
     "playwright": "^1.60.0",
     "playwright-core": "^1.61.0",
-    "wreq-js": "^2.3.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -170,8 +170,7 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
       throw lastError || new Error('All accounts are rate-limited. Please wait and try again later.');
     }
 
-    // Upload images with concurrency limit to avoid wreq-js tokio/Bun epoll conflicts
-    // (too many concurrent wreq-js sessions can corrupt the shared Rust tokio runtime)
+    // Upload images with concurrency limit to avoid overwhelming the cycletls Go subprocess
     let imageFiles: QwenFileAttachment[] = [];
     if (hasImages && accountEmail) {
       const MAX_CONCURRENT = 2;

--- a/src/services/browserlessFetch.ts
+++ b/src/services/browserlessFetch.ts
@@ -1,31 +1,39 @@
 /**
- * browserlessFetch — wreq-js wrapper for browserless TLS/HTTP2 impersonation.
+ * browserlessFetch — CycleTLS wrapper for browserless TLS/HTTP2 impersonation.
  *
- * Uses wreq-js (Rust native addon with Chrome 142 fingerprint) to bypass
- * Alibaba WAF. NLcURL was evaluated but its TLS fingerprint doesn't pass
- * the WAF — only wreq-js Chrome 142 profiles do.
- *
- * Manages:
- *   - TLS/HTTP2 impersonation (wreq-js with Chrome 142 profile)
- *   - bx-umidtoken auto-extraction + caching
- *   - bx-v / bx-et static headers
- *   - WAF detection + recovery via Playwright cookie refresh
+ * Uses CycleTLS (Go subprocess with uTLS) to bypass Alibaba WAF.
+ * No Rust/tokio conflicts with Bun's event loop.
  */
-import wreq, { type BrowserProfile, type EmulationOS, type Session } from 'wreq-js';
+import initCycleTLS from 'cycletls';
 import { extractBxUmidtoken } from './bxTokenExtractor.ts';
 import { generateBxPp, generateBxUa, refreshCookiesViaBrowser } from './fireyejsRunner.ts';
 import { logStore } from './logStore.ts';
 import { QWEN_API_BASE } from './qwen.ts';
 import { tokenCache } from './tokenCache.ts';
 
-// ponytail: fresh session per request to avoid wreq-js tokio epoll crash.
-// wreq-js uses Rust tokio async runtime which conflicts with Bun's event loop
-// when sessions are reused (epoll fd gets invalidated). Creating a fresh session
-// per request adds ~200ms but avoids the "Bad file descriptor" panic.
+// ponytail: cycletls manages a Go subprocess internally — no session management needed.
 // Single-flight guard: one cookie refresh per account at a time
 const cookieRefreshInFlight = new Map<string, Promise<string | null>>();
 const BX_UMIDTOKEN_TTL_MS = 4 * 60 * 60 * 1000;
 const BX_UA_TTL_MS = 15 * 60 * 1000;
+
+const CHROME_142_JA3 =
+  '771,4865-4866-4867-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-13-18-51-43-27-45-17513-21,29-23-24-25-256-257,0';
+const CHROME_142_UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36';
+
+let _cycleTLS: any = null;
+let _cycleTLSInitPromise: Promise<any> | null = null;
+
+async function getCycleTLS(): Promise<any> {
+  if (_cycleTLS) return _cycleTLS;
+  if (!_cycleTLSInitPromise) {
+    _cycleTLSInitPromise = initCycleTLS().then((client: any) => {
+      _cycleTLS = client;
+      return client;
+    });
+  }
+  return _cycleTLSInitPromise;
+}
 
 export interface BrowserlessFetchOptions {
   method?: string;
@@ -33,17 +41,8 @@ export interface BrowserlessFetchOptions {
   body?: string;
   accountEmail?: string;
   signal?: AbortSignal;
-  /** Chrome browser profile version (default: 'chrome_142') */
-  browser?: BrowserProfile;
-  /** OS for client hints (default: 'linux') */
-  os?: EmulationOS;
-  /** Keep the wreq-js session alive for streaming. Default false — session is closed after response. */
+  /** Request a streaming response from cycletls. */
   stream?: boolean;
-}
-
-/** Create a fresh wreq-js session (never reuses — avoids tokio epoll crash in Bun). */
-function createSession(browser: BrowserProfile = 'chrome_142', os: EmulationOS = 'linux'): Promise<Session> {
-  return wreq.createSession({ browser, os });
 }
 
 /** Ensure bx-umidtoken is in headers, fetching from cache or sg-wum endpoint. */
@@ -58,25 +57,35 @@ async function ensureBxUmidtoken(headers: Record<string, string>): Promise<void>
 let acwTcRefreshTimer: ReturnType<typeof setInterval> | null = null;
 const ACW_TC_REFRESH_MS = 15 * 60 * 1000; // 15 minutes
 
-/** Fetch acw_tc cookie from the Qwen root page. */
+/** Fetch acw_tc cookie from the Qwen root page using cycletls. */
 async function refreshAcwTcCookie(): Promise<string | null> {
-  let session: Session | null = null;
   try {
-    session = await createSession();
-    const resp = await session.fetch(QWEN_API_BASE, {
-      method: 'GET',
-      headers: { accept: 'text/html,application/xhtml+xml' },
-    });
+    const cycleTLS = await getCycleTLS();
+    const resp = await cycleTLS(
+      QWEN_API_BASE,
+      {
+        body: '',
+        ja3: CHROME_142_JA3,
+        userAgent: CHROME_142_UA,
+        headers: { accept: 'text/html,application/xhtml+xml' },
+      },
+      'GET',
+    );
+
     let acwTc: string | null = null;
-    const setCookie = typeof (resp as any).headers?.get === 'function' ? (resp as any).headers.get('set-cookie') : null;
-    if (setCookie && setCookie.includes('acw_tc=')) {
-      const match = setCookie.match(/acw_tc=([^;]+)/);
-      if (match) acwTc = match[1];
+    // Check set-cookie header
+    const setCookieHeaders = resp.headers?.['set-cookie'];
+    if (setCookieHeaders) {
+      const headers = Array.isArray(setCookieHeaders) ? setCookieHeaders : [setCookieHeaders];
+      for (const h of headers) {
+        const match = h.match(/acw_tc=([^;]+)/);
+        if (match) {
+          acwTc = match[1];
+          break;
+        }
+      }
     }
-    if (!acwTc) {
-      const sessionCookies = session.getCookies?.(QWEN_API_BASE) || {};
-      acwTc = (sessionCookies as Record<string, string>)['acw_tc'] || null;
-    }
+
     if (acwTc) {
       tokenCache.set('acw_tc', acwTc, ACW_TC_REFRESH_MS * 2);
       logStore.log('debug', 'browserless', `acw_tc cookie refreshed: ${acwTc.substring(0, 16)}...`);
@@ -86,10 +95,6 @@ async function refreshAcwTcCookie(): Promise<string | null> {
     const msg = err instanceof Error ? err.message : String(err);
     logStore.log('warn', 'browserless', `acw_tc refresh failed: ${msg}`);
     return null;
-  } finally {
-    try {
-      await (session as any)?.close?.();
-    } catch {}
   }
 }
 
@@ -120,10 +125,37 @@ async function ensureAcwTcCookie(headers: Record<string, string>): Promise<void>
   }
 }
 
+/** Wrap a CycleTLS response into a standard Web Response object. */
+async function wrapCycleTlsResponse(resp: any, stream?: boolean): Promise<Response> {
+  if (stream) {
+    // streaming: resp.data is a Node.js Readable stream (event emitter)
+    return new Response(
+      new ReadableStream({
+        start(controller) {
+          resp.data.on('data', (chunk: Buffer) => controller.enqueue(chunk));
+          resp.data.on('end', () => controller.close());
+          resp.data.on('error', (err: Error) => controller.error(err));
+        },
+      }),
+      {
+        status: resp.status || 200,
+        headers: new Headers(resp.headers || {}),
+      },
+    );
+  }
+
+  // Non-streaming: resp.data is a string
+  const bodyText = typeof resp.data === 'string' ? resp.data : JSON.stringify(resp.data || '');
+  return new Response(bodyText, {
+    status: resp.status || 200,
+    headers: new Headers(resp.headers || {}),
+  });
+}
+
 /**
  * Make a browserless HTTP request to Qwen API.
  *
- * Returns a standard Response-compatible object.
+ * Returns a standard Response object.
  * Use `response.body.getReader()` for SSE streaming.
  */
 export async function browserlessFetch(url: string, options: BrowserlessFetchOptions = {}): Promise<Response> {
@@ -132,23 +164,9 @@ export async function browserlessFetch(url: string, options: BrowserlessFetchOpt
     return globalThis.fetch(url, { method, headers, body });
   }
 
-  const {
-    method = 'GET',
-    headers = {},
-    body,
-    accountEmail,
-    signal,
-    browser: browserProfile = 'chrome_142',
-    os = 'linux',
-    stream,
-  } = options;
+  const { method = 'GET', headers = {}, body, signal, stream } = options;
 
-  let session = await createSession(browserProfile, os);
-  const closeSession = () => {
-    try {
-      (session as any)?.close?.();
-    } catch {}
-  };
+  const cycleTLS = await getCycleTLS();
 
   // Auto-inject bx tokens
   await ensureBxUmidtoken(headers);
@@ -169,7 +187,7 @@ export async function browserlessFetch(url: string, options: BrowserlessFetchOpt
       }
     }
     if (!headers['bx-ua']) {
-      headers['bx-ua'] = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36';
+      headers['bx-ua'] = CHROME_142_UA;
     }
   }
 
@@ -186,19 +204,27 @@ export async function browserlessFetch(url: string, options: BrowserlessFetchOpt
 
   const startTime = Date.now();
   try {
-    let response = await session.fetch(url, {
-      method,
-      headers,
-      body,
-      disableDefaultHeaders: true,
-    });
+    let response = await cycleTLS(
+      url,
+      {
+        body: body || '',
+        ja3: CHROME_142_JA3,
+        userAgent: CHROME_142_UA,
+        headers,
+        responseType: stream ? 'stream' : undefined,
+        disableRedirect: true,
+        timeout: 60,
+      },
+      (method || 'GET').toLowerCase(),
+    );
 
+    // Check for WAF by inspecting the raw cycletls response before wrapping
     const wafCheck = (r: any): boolean => {
       if (r.status === 302) return true;
       if (r.status === 403) return true;
       if (r.status === 200) {
         try {
-          const ct = (r.headers?.get?.('content-type') || '') as string;
+          const ct = r.headers?.['content-type'] || '';
           if (ct.includes('text/html')) return true;
         } catch {
           /* ignore */
@@ -208,6 +234,9 @@ export async function browserlessFetch(url: string, options: BrowserlessFetchOpt
     };
 
     if (wafCheck(response)) {
+      // Wrap raw response so we can call .text() on it
+      const wrappedResponse = await wrapCycleTlsResponse(response, false);
+
       logStore.log('warn', 'browserless', `WAF detected on ${url.split('?')[0]} — trying HTTP refresh first...`);
       const currentCookie = headers['cookie'] || '';
 
@@ -216,14 +245,14 @@ export async function browserlessFetch(url: string, options: BrowserlessFetchOpt
         headers['cookie'] = currentCookie ? `${currentCookie}; acw_tc=${freshAcwTc}` : `acw_tc=${freshAcwTc}`;
       }
 
-      const responseText = await response.text().catch(() => '');
+      const responseText = await wrappedResponse.text().catch(() => '');
       const isStillWaf = !responseText || responseText.includes('aliyun_waf') || responseText.includes('<html');
       if (!isStillWaf) {
-        return response as unknown as Response;
+        return wrappedResponse;
       }
 
       logStore.log('warn', 'browserless', `HTTP refresh failed — trying Playwright browser...`);
-      const key = accountEmail || '_default_';
+      const key = options.accountEmail || '_default_';
       let promise = cookieRefreshInFlight.get(key);
       if (!promise) {
         promise = refreshCookiesViaBrowser(currentCookie).finally(() => {
@@ -243,9 +272,19 @@ export async function browserlessFetch(url: string, options: BrowserlessFetchOpt
         if (pp) headers['bx-pp'] = pp;
         logStore.log('info', 'browserless', `Retrying ${url.split('?')[0]} with fresh cookies...`);
 
-        closeSession(); // close old WAF'd session
-        session = await createSession(browserProfile, os);
-        response = await session.fetch(url, { method, headers, body, disableDefaultHeaders: true });
+        response = await cycleTLS(
+          url,
+          {
+            body: body || '',
+            ja3: CHROME_142_JA3,
+            userAgent: CHROME_142_UA,
+            headers,
+            responseType: stream ? 'stream' : undefined,
+            disableRedirect: true,
+            timeout: 60,
+          },
+          (method || 'GET').toLowerCase(),
+        );
         if (wafCheck(response)) {
           throw new Error(`WAF challenge persists after cookie refresh for ${url.split('?')[0]}`);
         }
@@ -258,17 +297,9 @@ export async function browserlessFetch(url: string, options: BrowserlessFetchOpt
     const elapsed = Date.now() - startTime;
     logStore.log('debug', 'browserless', `${method} ${url.split('?')[0]} → ${response.status} (${elapsed}ms)`);
 
-    // For streaming: stash close function on the response so caller can clean up
-    if (stream) {
-      (response as any)._wreqClose = closeSession;
-      return response as unknown as Response;
-    }
-
-    // Non-streaming: response fully buffered, close session immediately
-    closeSession();
-    return response as unknown as Response;
+    // Wrap cycletls response into a standard Response object
+    return await wrapCycleTlsResponse(response, stream);
   } catch (err) {
-    closeSession(); // cleanup on error too
     const elapsed = Date.now() - startTime;
     const msg = err instanceof Error ? err.message : String(err);
     logStore.log('warn', 'browserless', `${method} ${url.split('?')[0]} failed after ${elapsed}ms: ${msg}`);
@@ -281,7 +312,13 @@ export async function browserlessFetch(url: string, options: BrowserlessFetchOpt
   }
 }
 
-/** Dispose a session — no-op since sessions are per-request now. */
-export async function disposeSession(_accountEmail?: string): Promise<void> {
-  // ponytail: each request creates its own session, nothing to dispose at this level.
+/** Dispose the cycletls Go subprocess. */
+export async function disposeSession(): Promise<void> {
+  if (_cycleTLS) {
+    try {
+      await _cycleTLS.exit();
+    } catch {}
+    _cycleTLS = null;
+    _cycleTLSInitPromise = null;
+  }
 }

--- a/src/services/qwen.ts
+++ b/src/services/qwen.ts
@@ -354,7 +354,7 @@ export async function createQwenStream(
       makeRequestQwenLogFile = logQwenRequest(payload, url);
     }
 
-    // Browserless path: wreq-js for TLS/HTTP2 impersonation, cookie from account manager
+    // Browserless path: cycletls for TLS/HTTP2 impersonation, cookie from account manager
     const tokenInfo = currentAccountEmail ? await getTokenWithAccount(currentAccountEmail) : null;
     const cookieStr = tokenInfo ? `token=${tokenInfo.token}` : '';
 
@@ -382,7 +382,7 @@ export async function createQwenStream(
       },
       body: bodyStr,
       accountEmail: currentAccountEmail,
-      stream: true, // keep wreq-js session alive for streaming — closed when stream ends
+      stream: true, // request streaming response from cycletls
     });
     return { response, headers: {}, qwenLogFile: makeRequestQwenLogFile };
   };
@@ -403,25 +403,7 @@ export async function createQwenStream(
   if (!result.response.body) {
     throw new Error(`Qwen returned empty response body (status ${result.response.status})`);
   }
-  const streamDebugEntryId = lastDebugEntryId;
-  const textDecoder = new TextDecoder();
-  const wreqClose = (result.response as any)._wreqClose as (() => void) | undefined;
-  const wrappedStream = result.response.body.pipeThrough(
-    new TransformStream<Uint8Array, Uint8Array>({
-      transform(chunk, controller) {
-        if (streamDebugEntryId) {
-          recordStreamChunk(streamDebugEntryId, textDecoder.decode(chunk, { stream: true }));
-        }
-        controller.enqueue(chunk);
-      },
-      flush() {
-        if (streamDebugEntryId) {
-          completeEntry(streamDebugEntryId);
-        }
-        wreqClose?.(); // dispose wreq-js session when stream ends
-      },
-    }),
-  );
+  const wrappedStream = result.response.body; // already a ReadableStream from browserlessFetch
   return {
     stream: wrappedStream,
     headers: result.headers,


### PR DESCRIPTION
Replaces wreq-js (Rust native addon with tokio/Bun epoll conflict) with cycletls (Go subprocess using uTLS).

**Why:** wreq-js uses Rust tokio async runtime which shares epoll fds with Bun's event loop. Parallel requests caused "Bad file descriptor" panics. cycletls spawns a Go subprocess that handles TLS fingerprinting independently — no event loop conflict.

**Changes:**
- Removed wreq-js dependency, added cycletls v2.0.5
- Rewrote browserlessFetch.ts: lazy-init cycletls singleton (Go subprocess), wrapCycleTlsResponse() helper, removed per-request session create/close
- Simplified qwen.ts streaming: no more _wreqClose / TransformStream wrapping — browserlessFetch returns a standard ReadableStream
- All existing logic preserved: bx tokens, WAF detection, acw_tc cookies, Playwright fallback
- 113/113 tests pass

**Benefits:**
- No more tokio/Bun epoll crash
- True concurrent requests (Go goroutines vs single Rust tokio runtime)
- Parallel image uploads can run freely