### PR TITLE
Fix empty Claude Code responses: CAPTCHA handling, local_mcp budget, tool normalization

### DIFF
--- a/scripts/add-accounts.ts
+++ b/scripts/add-accounts.ts
@@ -1,0 +1,88 @@
+/**
+ * Batch-add Qwen accounts to qwengate for multi-account round-robin rotation
+ * with automatic failover. Hot-reloads — the running server picks up
+ * accounts.json changes on the fly (fs.watch with debounce).
+ *
+ * Usage:
+ *   QWEN_ACCOUNTS="user1@example.com:pass1,user2@example.com:pass2" bun scripts/add-accounts.ts
+ *   bun scripts/add-accounts.ts "user1@example.com:pass1" "user2@example.com:pass2"
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DATA_DIR = join(ROOT, '.qwen');
+const ACCOUNTS_FILE = join(DATA_DIR, 'accounts.json');
+
+interface AccountEntry {
+  email: string;
+  password: string;
+  throttledUntil: number;
+  disabled: boolean;
+}
+
+function parseAccounts(): Array<{ email: string; password: string }> {
+  const fromEnv = (process.env.QWEN_ACCOUNTS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const fromArgs = process.argv.slice(2);
+  const raw: string[] = [...fromEnv, ...fromArgs];
+
+  const out: Array<{ email: string; password: string }> = [];
+  for (const item of raw) {
+    const idx = item.lastIndexOf(':');
+    if (idx <= 0) {
+      console.error(`[add-accounts] Skip malformed entry (expected email:password): ${item}`);
+      continue;
+    }
+    const email = item.slice(0, idx).trim();
+    const password = item.slice(idx + 1);
+    if (email && password) out.push({ email, password });
+  }
+  return out;
+}
+
+function loadExisting(): AccountEntry[] {
+  if (!existsSync(ACCOUNTS_FILE)) return [];
+  try {
+    const data = JSON.parse(readFileSync(ACCOUNTS_FILE, 'utf-8'));
+    return (Array.isArray(data) ? data : []).map((a: any) => ({
+      email: String(a.email || '').trim(),
+      password: String(a.password || ''),
+      throttledUntil: Number(a.throttledUntil || 0),
+      disabled: !!a.disabled,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+const incoming = parseAccounts();
+if (incoming.length === 0) {
+  console.error('[add-accounts] No accounts provided. Use QWEN_ACCOUNTS="a:b,c:d" env or pass email:password args.');
+  process.exit(1);
+}
+
+const existing = loadExisting();
+const seen = new Set(existing.map((a) => a.email.toLowerCase()));
+const added: string[] = [];
+const skipped: string[] = [];
+for (const acct of incoming) {
+  if (seen.has(acct.email.toLowerCase())) {
+    skipped.push(acct.email);
+    continue;
+  }
+  existing.push({ ...acct, throttledUntil: 0, disabled: false });
+  seen.add(acct.email.toLowerCase());
+  added.push(acct.email);
+}
+
+mkdirSync(DATA_DIR, { recursive: true });
+writeFileSync(ACCOUNTS_FILE, JSON.stringify(existing, null, 2) + '\n', 'utf-8');
+
+console.log(`[add-accounts] Added: ${added.length} (${added.join(', ') || 'none'})`);
+console.log(`[add-accounts] Skipped (already present): ${skipped.length} (${skipped.join(', ') || 'none'})`);
+console.log(`[add-accounts] Total accounts in ${ACCOUNTS_FILE}: ${existing.length}`);
+console.log('[add-accounts] Running server picks this up automatically via fs.watch — no restart needed.');

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -436,7 +436,15 @@ if (import.meta.main) {
             logStore.log('warn', 'boot', `[2/5] Account config failed for ${acct.email}: ${err.message}`),
           );
         }
-        logStore.log('info', 'boot', `[2/5] Accounts configured: ${acctList.length} ready`);
+        logStore.log('info', 'boot', '[2/5] Accounts configured: ' + `${acctList.length} ready`);
+
+        // Pool pre-created empty Qwen chats so the first request of a turn doesn't pay chats/new latency
+        try {
+          const { sessionPool } = await import('./services/sessionPool.ts');
+          sessionPool.initialize().catch(() => {});
+        } catch (err: any) {
+          logStore.log('warn', 'boot', `[2/5] Session pool warm-up failed: ${err.message}`);
+        }
       } catch (err: any) {
         logStore.log('warn', 'boot', `[2/5] Configure failed: ${err.message}`);
       }

--- a/src/routes/anthropic.ts
+++ b/src/routes/anthropic.ts
@@ -11,6 +11,7 @@ import { uploadImageAsFile, uploadLargeTextAsFile } from '../services/qwenFileUp
 import { sessionPool } from '../services/sessionPool.ts';
 import { cleanTextOfXmlArtifacts, parseXmlToolCalls, xmlToolCallToParsed } from '../tools/xmlToolParser.ts';
 import type { OpenAIRequest, ParsedToolCall } from '../types/openai.ts';
+import { resolveThinkingLevel } from '../utils/thinkingLevel.ts';
 import { checkContextWindow, estimateTokens } from '../utils/tokenEstimator.ts';
 import {
   acquireSessionWithCorrections,
@@ -27,22 +28,23 @@ import { extractLocalMcpToolCalls } from './chatStreamingHelpers.ts';
 // ── Anthropic → Qwen model map ─────────────────────────────────────
 
 // ponytail: use dotted model names matching the Qwen API (/v1/models response).
-// models.json keys use dashes (qwen3-7-max) but Qwen API expects dots (qwen3.7-max).
-const ANTHROPIC_TO_QWEN: Record<string, string> = {
-  'claude-sonnet-4-20250514': 'qwen3.7-max',
-  'claude-sonnet-4-20241022': 'qwen3.6-plus',
-  'claude-3-5-sonnet-20241022': 'qwen3.6-plus',
-  'claude-opus-4-20250514': 'qwen3.7-max',
-  'claude-opus-4-8': 'qwen3.7-max',
-  'claude-sonnet-4-8': 'qwen3.7-max',
-  'claude-3-opus-20240229': 'qwen3.7-max',
-  'claude-sonnet-4-6-20250514': 'qwen3.7-max',
-  'claude-3-haiku-20240307': 'qwen3.5-flash',
-};
-const DEFAULT_QWEN_MODEL = 'qwen3.7-max';
+// Routing matches the family keyword anywhere in the name so both current
+// (claude-sonnet-4-…) and legacy (claude-3-5-sonnet-20241022) spellings work:
+//   Opus   → qwen3.8-max  (flagship)
+//   Sonnet → qwen3.7-max  (workhorse)
+//   Haiku  → qwen3.7-plus (fast/vision)
+const QWEN_MODEL_BY_TIER: Array<[pattern: RegExp, model: string]> = [
+  [/\bopus\b/i, 'qwen3.8-max'],
+  [/\bsonnet\b/i, 'qwen3.7-max'],
+  [/\bhaiku\b/i, 'qwen3.7-plus'],
+];
+const DEFAULT_QWEN_MODEL = 'qwen3.8-max';
 
 function mapModel(anthropicModel: string): string {
-  return ANTHROPIC_TO_QWEN[anthropicModel] || DEFAULT_QWEN_MODEL;
+  for (const [pattern, model] of QWEN_MODEL_BY_TIER) {
+    if (pattern.test(anthropicModel)) return model;
+  }
+  return DEFAULT_QWEN_MODEL;
 }
 
 // ── Request conversion ─────────────────────────────────────────────
@@ -307,11 +309,7 @@ async function setupAnthropicSession(
     });
   }
 
-  const {
-    qwenMessages: processedMessages,
-    systemContent,
-    toolResultsContent,
-  } = buildQwenMessages(cleanedMessages, body, availableTokens, toolCalling);
+  const { qwenMessages: processedMessages, toolResultsContent } = buildQwenMessages(cleanedMessages, body, availableTokens, toolCalling);
 
   const MAX_INLINE_CHARS = 50000;
   let inlineContent = processedMessages[0].content as string;
@@ -335,7 +333,7 @@ async function setupAnthropicSession(
   }
 
   let lastFailedEmail: string | undefined;
-  const isThinkingModel = !body.model.includes('no-thinking');
+  const isThinkingModel = body.thinkingLevel !== 'off' && !body.model.includes('no-thinking');
   let lastError: any;
 
   for (let attempt = 0; attempt < MAX_ACCOUNT_RETRIES; attempt++) {
@@ -375,9 +373,11 @@ async function setupAnthropicSession(
       }
     }
 
-    if (accountEmail && (systemContent || toolResultsContent || chatHistoryContent)) {
+    if (accountEmail && (toolResultsContent || chatHistoryContent)) {
       const parts: string[] = [];
-      if (systemContent) parts.push(`<system-instructions>\n${systemContent}\n</system-instructions>`);
+      parts.push(
+        `<REFERENCE_CONTEXT>\nThe following are older tool results and chat history from this conversation.\nThey are background reference — the actual current request appears inline above.\nRead them only if you need details not present inline.\n</REFERENCE_CONTEXT>`,
+      );
       if (toolResultsContent) parts.push(`<tool-results>\n${toolResultsContent}\n</tool-results>`);
       if (chatHistoryContent) parts.push(`<chat_history>\n${chatHistoryContent}\n</chat_history>`);
       try {
@@ -1047,6 +1047,17 @@ export async function anthropicMessages(c: Context) {
     // Map model
     const mappedModel = mapModel(anthropicModel);
 
+    // Resolve thinking level from Claude Code's `thinking` block (budget_tokens)
+    // + THINKING_MODE config. Levels: off / summary / full.
+    const thinkingLevel = resolveThinkingLevel({
+      mode: config.get('THINKING_MODE', 'auto'),
+      model: mappedModel,
+      intent: rawBody.thinking ? { ...rawBody.thinking } : undefined,
+    });
+    if (rawBody.thinking) {
+      logStore.log('debug', 'chat', `[Anthropic] thinking=${JSON.stringify(rawBody.thinking)} → level=${thinkingLevel}`);
+    }
+
     // Convert messages and tools to OpenAI format
     const openaiMessages = anthropicMessagesToOpenAI(messages, system);
     const convertedTools = anthropicToolsToOpenAI(tools);
@@ -1056,6 +1067,7 @@ export async function anthropicMessages(c: Context) {
       model: mappedModel,
       messages: openaiMessages,
       stream: false,
+      thinkingLevel,
       ...(convertedTools.length > 0 && { tools: convertedTools }),
       ...(toolChoice && { tool_choice: toolChoice }),
     };

--- a/src/routes/anthropic.ts
+++ b/src/routes/anthropic.ts
@@ -5,7 +5,7 @@ import { pickAccount, throttleAccount } from '../services/auth.ts';
 import { config } from '../services/configService.ts';
 import { logStore } from '../services/logStore.ts';
 import { modelRouter } from '../services/modelRouter.ts';
-import { RetryableQwenStreamError } from '../services/qwen.ts';
+import { CaptchaSolvedError, RetryableQwenStreamError } from '../services/qwen.ts';
 import type { QwenFileAttachment } from '../services/qwenFileUpload.ts';
 import { uploadImageAsFile, uploadLargeTextAsFile } from '../services/qwenFileUpload.ts';
 import { sessionPool } from '../services/sessionPool.ts';
@@ -170,6 +170,66 @@ function normalizeToolName(name: string): string {
   return CASE_MAP[name] || name;
 }
 
+// ── Tool-call arg normalizer (schema-driven) ───────────────────────
+
+// Claude Code sends tool schemas with snake_case property names
+// (file_path, old_string, new_string). The old hardcoded snake→camel map
+// emitted filePath/oldString to Claude Code, which validates args against its
+// OWN schema → "required parameter file_path is missing. An unexpected
+// parameter filePath was provided" → infinite client retry loop.
+// Instead, normalize Qwen's args to the EXACT property names the client schema
+// declares (case/underscore-insensitive match), and require only what the
+// schema lists as required. Falls back to old behavior for unknown tools.
+export function buildToolCallNormalizer(tools: any[] | undefined): {
+  normalizeArgs(toolName: string, args: any): any;
+  missingRequired(toolName: string, args: any): string[];
+} {
+  const propsByTool = new Map<string, Set<string>>();
+  const requiredByTool = new Map<string, string[]>();
+  const normKey = (s: string): string => s.replace(/[_-]/g, '').toLowerCase();
+
+  for (const t of tools || []) {
+    const fn = t?.function || {};
+    const name = fn.name;
+    if (!name) continue;
+    const params = fn.parameters || {};
+    const props = new Set<string>(Object.keys(params.properties || {}));
+    propsByTool.set(name, props);
+    const required = Array.isArray(params.required) ? params.required : [...props];
+    requiredByTool.set(name, required);
+  }
+
+  function findProp(toolName: string, key: string): string | undefined {
+    const props = propsByTool.get(toolName);
+    if (!props) return undefined;
+    if (props.has(key)) return key;
+    const nk = normKey(key);
+    for (const p of props) {
+      if (normKey(p) === nk) return p;
+    }
+    return undefined;
+  }
+
+  return {
+    normalizeArgs(toolName: string, args: any): any {
+      const mapped: any = {};
+      for (const [k, v] of Object.entries(args || {})) {
+        const canonical = findProp(normalizeToolName(toolName), k) || findProp(toolName, k) || k;
+        mapped[canonical] = v;
+      }
+      return mapped;
+    },
+    missingRequired(toolName: string, args: any): string[] {
+      const normalizedName = normalizeToolName(toolName);
+      const required = requiredByTool.get(normalizedName) || requiredByTool.get(toolName);
+      if (!required || required.length === 0) {
+        return args && typeof args === 'object' && Object.keys(args).length > 0 ? [] : ['*'];
+      }
+      return required.filter((p) => args[p] === undefined || args[p] === null || args[p] === '');
+    },
+  };
+}
+
 // ponytail: simple formatter for Anthropic content blocks in log display
 function formatContent(content: any): string {
   if (typeof content === 'string') return content;
@@ -189,7 +249,7 @@ function formatContent(content: any): string {
     .join('\n');
 }
 
-function convertOpenAIResponseToAnthropic(openAIResp: any, requestModel: string): any {
+function convertOpenAIResponseToAnthropic(openAIResp: any, requestModel: string, tools?: any[]): any {
   const choice = openAIResp.choices?.[0];
   const message = choice?.message || {};
   const content: any[] = [];
@@ -197,33 +257,7 @@ function convertOpenAIResponseToAnthropic(openAIResp: any, requestModel: string)
     content.push({ type: 'text', text: message.content });
   }
 
-  // ponytail: static Claude Code required param map — adapt if tools vary
-  const REQUIRED_PARAMS: Record<string, string[]> = {
-    Bash: ['command'],
-    Read: ['filePath'],
-    Edit: ['filePath', 'oldString', 'newString'],
-    Write: ['filePath', 'content'],
-  };
-
-  function mapParamName(paramName: string): string {
-    const SNAKE_TO_CAMEL: Record<string, string> = {
-      file_path: 'filePath',
-      old_string: 'oldString',
-      new_string: 'newString',
-    };
-    return SNAKE_TO_CAMEL[paramName] || paramName;
-  }
-
-  function isValidToolCall(name: string, args: any): boolean {
-    const required = REQUIRED_PARAMS[name];
-    if (required) {
-      const missing = required.filter((p) => args[p] === undefined || args[p] === null || args[p] === '');
-      if (missing.length > 0) return false;
-    } else if (!args || typeof args !== 'object' || Object.keys(args).length === 0) {
-      return false;
-    }
-    return true;
-  }
+  const { normalizeArgs, missingRequired } = buildToolCallNormalizer(tools);
 
   if (message.tool_calls) {
     for (const tc of message.tool_calls) {
@@ -234,13 +268,11 @@ function convertOpenAIResponseToAnthropic(openAIResp: any, requestModel: string)
         /* ignore */
       }
       if (!args || typeof args !== 'object') continue;
-      // Map snake_case to camelCase
-      const mapped: any = {};
-      for (const [k, v] of Object.entries(args)) {
-        mapped[mapParamName(k)] = v;
-      }
+      // Map Qwen args to the tool schema's canonical property names
+      const mapped = normalizeArgs(tc.function.name, args);
       const normalizedName = normalizeToolName(tc.function.name);
-      if (!isValidToolCall(normalizedName, mapped)) {
+      const missing = missingRequired(normalizedName, mapped);
+      if (missing.length > 0) {
         logStore.log(
           'debug',
           'chat',
@@ -333,11 +365,13 @@ async function setupAnthropicSession(
   }
 
   let lastFailedEmail: string | undefined;
+  let retrySameAccount: string | undefined;
   const isThinkingModel = body.thinkingLevel !== 'off' && !body.model.includes('no-thinking');
   let lastError: any;
 
   for (let attempt = 0; attempt < MAX_ACCOUNT_RETRIES; attempt++) {
-    const selectedAccount = await pickAccount(lastFailedEmail);
+    let selectedAccount = retrySameAccount ? { email: retrySameAccount } : await pickAccount(lastFailedEmail);
+    retrySameAccount = undefined;
     const accountEmail = selectedAccount?.email;
     logStore.log(
       'debug',
@@ -440,6 +474,14 @@ async function setupAnthropicSession(
         logStore.log('warn', 'chat', `[Anthropic]   -> rate-limited, trying next account`);
         lastFailedEmail = resolvedEmail;
         lastError = err;
+        continue;
+      }
+      if (err instanceof CaptchaSolvedError) {
+        // CAPTCHA was solved interactively and saveCookies() already cleared
+        // the throttle — retry on the SAME account, do NOT throttle it.
+        logStore.log('info', 'chat', `[Anthropic]   -> CAPTCHA solved on ${resolvedEmail}, retrying same account`);
+        lastError = undefined;
+        retrySameAccount = resolvedEmail;
         continue;
       }
       if (
@@ -548,6 +590,7 @@ async function handleAnthropicStream(
   nextParentId: string | null,
   sessionHeaders: any,
   promptTokenEstimate: number = 0,
+  tools?: any[],
 ): Promise<Response> {
   c.header('Content-Type', 'text/event-stream');
   c.header('Cache-Control', 'no-cache');
@@ -806,25 +849,10 @@ async function handleAnthropicStream(
         );
       }
 
-      // Validate and filter tool calls
-      // ponytail: static Claude Code required param map — upgrade if tools vary
-      const REQUIRED_PARAMS: Record<string, string[]> = {
-        Bash: ['command'],
-        Read: ['filePath'],
-        Edit: ['filePath', 'oldString', 'newString'],
-        Write: ['filePath', 'content'],
-      };
-
-      // ponytail: snake_case → camelCase mapping for Qwen param names
-      function mapParamName(toolName: string, paramName: string): string {
-        const SNAKE_TO_CAMEL: Record<string, string> = {
-          file_path: 'filePath',
-          old_string: 'oldString',
-          new_string: 'newString',
-          tool_call_id: 'toolCallId',
-        };
-        return SNAKE_TO_CAMEL[paramName] || paramName;
-      }
+      // Validate and filter tool calls using the actual tool schemas sent by
+      // Claude Code (property names + required). Qwen's camelCase variants are
+      // normalized to the schema's snake_case names (file_path, old_string…).
+      const { normalizeArgs, missingRequired } = buildToolCallNormalizer(tools);
 
       function validateToolCall(tc: ParsedToolCall): { valid: boolean; fixedArgs: any } {
         let args: any = {};
@@ -835,28 +863,18 @@ async function handleAnthropicStream(
         }
         if (!args || typeof args !== 'object') return { valid: false, fixedArgs: {} };
 
-        // Map snake_case to camelCase
-        const mapped: any = {};
-        for (const [k, v] of Object.entries(args)) {
-          mapped[mapParamName(tc.name, k)] = v;
-        }
+        const mapped = normalizeArgs(tc.name, args);
         args = mapped;
 
         const toolName = normalizeToolName(tc.name);
-        const required = REQUIRED_PARAMS[toolName];
-        if (required) {
-          const missing = required.filter((p) => args[p] === undefined || args[p] === null || args[p] === '');
-          if (missing.length > 0) {
-            logStore.log(
-              'debug',
-              'chat',
-              `[Anthropic] Skipped tool call: ${tc.name} missing required params: ${missing.join(', ')} (had: ${JSON.stringify(args)})`,
-            );
-            return { valid: false, fixedArgs: args };
-          }
-        } else if (Object.keys(args).length === 0) {
-          logStore.log('debug', 'chat', `[Anthropic] Skipped tool call: ${tc.name} (no params)`);
-          return { valid: false, fixedArgs: {} };
+        const missing = missingRequired(toolName, args);
+        if (missing.length > 0) {
+          logStore.log(
+            'debug',
+            'chat',
+            `[Anthropic] Skipped tool call: ${tc.name} missing required params: ${missing.join(', ')} (had: ${JSON.stringify(args)})`,
+          );
+          return { valid: false, fixedArgs: args };
         }
 
         return { valid: true, fixedArgs: args };
@@ -1168,7 +1186,7 @@ export async function anthropicMessages(c: Context) {
           <any>openAIResponse.status,
         );
       }
-      const anthropicResp = convertOpenAIResponseToAnthropic(openAIResp, anthropicModel);
+      const anthropicResp = convertOpenAIResponseToAnthropic(openAIResp, anthropicModel, convertedTools);
       logStore.log(
         'debug',
         'chat',
@@ -1191,6 +1209,7 @@ export async function anthropicMessages(c: Context) {
       nextParentId,
       sessionHeaders,
       promptTokenEstimate,
+      convertedTools,
     );
     logStore.log('debug', 'chat', `[Anthropic] Streaming completed latency=${Date.now() - _requestStartTime}ms`);
     cancelWatchdog();

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -10,6 +10,7 @@ import { uploadImageAsFile, uploadLargeTextAsFile } from '../services/qwenFileUp
 import { sessionPool } from '../services/sessionPool.ts';
 import { cleanTextOfXmlArtifacts } from '../tools/xmlToolParser.ts';
 import { OpenAIRequest } from '../types/openai.ts';
+import { resolveThinkingLevel } from '../utils/thinkingLevel.ts';
 import { checkContextWindow, estimateTokens } from '../utils/tokenEstimator.ts';
 import { validateOpenAIRequest } from '../utils/validation.ts';
 import {
@@ -65,6 +66,15 @@ async function parseRequestBody(c: Context) {
   const toolCalling = config.getBool('TOOL_CALLING', true);
   const cleanOutput = config.getBool('CLEAN_OUTPUT', true);
 
+  // Resolve thinking level from client reasoning_effort / thinking block + config
+  const thinkingLevel = resolveThinkingLevel({
+    mode: config.get('THINKING_MODE', 'auto'),
+    model: body.model as string,
+    intent: body.thinking ? { ...body.thinking } : undefined,
+    reasoningEffort: body.reasoning_effort,
+  });
+  body.thinkingLevel = thinkingLevel;
+
   const messages = body.messages || [];
   handleImageModelFallback(body, messages);
   const { maxContext, maxOutput } = getModelSpecs(body);
@@ -115,11 +125,7 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
     });
   }
 
-  const {
-    qwenMessages: processedMessages,
-    systemContent,
-    toolResultsContent,
-  } = buildQwenMessages(cleanedMessages, body, availableTokens, toolCalling);
+  const { qwenMessages: processedMessages, toolResultsContent } = buildQwenMessages(cleanedMessages, body, availableTokens, toolCalling);
 
   // ── Inline content truncation ─────────────────────────────────
   // Keep the most recent ~50k characters inline; push older history
@@ -158,7 +164,7 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
   // (accounts can't access files uploaded by other accounts — must share the account)
   let lastFailedEmail: string | undefined;
 
-  const isThinkingModel = !body.model.includes('no-thinking');
+  const isThinkingModel = body.thinkingLevel !== 'off' && !body.model.includes('no-thinking');
   const MAX_ACCOUNT_RETRIES = 5;
   let lastError: any;
 
@@ -191,11 +197,15 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
       }
     }
 
-    // Upload a single context file: system instructions + tool results + older chat history
-    // Merging cuts upload overhead in half (one STS token, one OSS upload, one parse poll)
-    if (accountEmail && (systemContent || toolResultsContent || chatHistoryContent)) {
+    // Upload a single context file: tool results + older chat history.
+    // System instructions are NOT uploaded — they now stay inline in the
+    // prompt (buildQwenMessages), otherwise the model fixates on the file
+    // ("context.txt contains only instructions") and returns empty replies.
+    if (accountEmail && (toolResultsContent || chatHistoryContent)) {
       const parts: string[] = [];
-      if (systemContent) parts.push(`<system-instructions>\n${systemContent}\n</system-instructions>`);
+      parts.push(
+        `<REFERENCE_CONTEXT>\nThe following are older tool results and chat history from this conversation.\nThey are background reference — the actual current request appears inline above.\nRead them only if you need details not present inline.\n</REFERENCE_CONTEXT>`,
+      );
       if (toolResultsContent) parts.push(`<tool-results>\n${toolResultsContent}\n</tool-results>`);
       if (chatHistoryContent) parts.push(`<chat_history>\n${chatHistoryContent}\n</chat_history>`);
       const combinedContent = parts.join('\n\n');

--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -4,7 +4,7 @@ import { pickAccount, throttleAccount } from '../services/auth.ts';
 import { config } from '../services/configService.ts';
 import { logStore } from '../services/logStore.ts';
 import { modelRouter } from '../services/modelRouter.ts';
-import { RetryableQwenStreamError } from '../services/qwen.ts';
+import { CaptchaSolvedError, RetryableQwenStreamError } from '../services/qwen.ts';
 import type { QwenFileAttachment } from '../services/qwenFileUpload.ts';
 import { uploadImageAsFile, uploadLargeTextAsFile } from '../services/qwenFileUpload.ts';
 import { sessionPool } from '../services/sessionPool.ts';
@@ -163,13 +163,15 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
   // File upload happens inside retry loop using the same account as the request
   // (accounts can't access files uploaded by other accounts — must share the account)
   let lastFailedEmail: string | undefined;
+  let retrySameAccount: string | undefined;
 
   const isThinkingModel = body.thinkingLevel !== 'off' && !body.model.includes('no-thinking');
   const MAX_ACCOUNT_RETRIES = 5;
   let lastError: any;
 
   for (let attempt = 0; attempt < MAX_ACCOUNT_RETRIES; attempt++) {
-    const selectedAccount = await pickAccount(lastFailedEmail);
+    const selectedAccount = retrySameAccount ? { email: retrySameAccount } : await pickAccount(lastFailedEmail);
+    retrySameAccount = undefined;
     const accountEmail = selectedAccount?.email;
     if (!selectedAccount && attempt > 0) {
       // On retry: if still no accounts, all are throttled — stop retrying
@@ -279,6 +281,14 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
       }
       // Bot detection / CAPTCHA: Qwen rejected BEFORE processing (safe to retry on another account).
       // Throttle the detected account so pickAccount won't pick it again.
+      if (err instanceof CaptchaSolvedError) {
+        // CAPTCHA was solved interactively and saveCookies() already cleared
+        // the throttle — retry on the SAME account, do NOT throttle it.
+        logStore.log('info', 'chat', `[Chat]   -> CAPTCHA solved on ${resolvedEmail}, retrying same account`);
+        lastError = undefined;
+        retrySameAccount = resolvedEmail;
+        continue;
+      }
       if (
         (err.message || '').includes('FAIL_SYS_USER_VALIDATE') ||
         (err.message || '').includes('CAPTCHA') ||

--- a/src/routes/chatHelpers.ts
+++ b/src/routes/chatHelpers.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import modelSpecs from '../models.json' with { type: 'json' };
+import { config } from '../services/configService.ts';
+import { logStore } from '../services/logStore.ts';
 import { modelRouter } from '../services/modelRouter.ts';
 import { buildFeatureConfig, createQwenStream } from '../services/qwen.ts';
 import { sessionPool } from '../services/sessionPool.ts';
@@ -95,7 +97,17 @@ export function buildQwenMessages(messages: any[], body: any, availableTokens: n
         .replace(CONTROL_CHAR_RE, '')
         .trim();
 
-      if (sanitized.length === 0) continue;
+      if (sanitized.length === 0) {
+        // The user turn contained ONLY <system-reminder> blocks (e.g. Claude Code
+        // SessionStart hook / superpowers sync). Dropping it leaves Qwen with a
+        // system-only prompt and no user content, which makes it return an empty
+        // end_turn — causing Claude Code to churn forever without answering.
+        // Keep the reminders as the user turn instead.
+        if (sysReminders.length > 0) {
+          segments.push(`<user>\n${sysReminders.join('\n\n')}\n</user>`);
+        }
+        continue;
+      }
 
       const charLimit = Math.floor(availableTokens * 3.0);
       const truncated =
@@ -163,10 +175,26 @@ export function buildQwenMessages(messages: any[], body: any, availableTokens: n
     }
   }
 
-  // Single user message with all history wrapped in <user>/<assist> tags
+  // Single user message with all history wrapped in <user>/<assist> tags.
+  // System instructions MUST stay inline (at the top) — previously they were
+  // sent only to the uploaded context.txt file, which made the model focus on
+  // the file ("context.txt contains only instructions") instead of answering,
+  // often returning an empty end_turn. Keeping them inline fixes that.
   let prompt = segments.length > 0 ? segments.join('\n\n') : '';
+  const inlineSystem = systemParts
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .join('\n\n');
+  if (inlineSystem) {
+    prompt = `<system>\n${inlineSystem}\n</system>\n\n${prompt}`;
+  }
 
-  const featureConfig = buildFeatureConfig(true);
+  // Thinking level is resolved by the route handlers (Anthropic / OpenAI)
+  // from the client's thinking intent + THINKING_MODE config, then attached
+  // to body.thinkingLevel. Fall back to the -no-thinking model suffix.
+  const thinkingLevel: 'off' | 'summary' | 'full' =
+    (body.thinkingLevel as 'off' | 'summary' | 'full' | undefined) || (body.model.includes('-no-thinking') ? 'off' : 'summary');
+  const featureConfig = buildFeatureConfig(thinkingLevel !== 'off', thinkingLevel === 'full' ? 'full' : 'summary');
 
   if (body.tools && Array.isArray(body.tools) && body.tools.length > 0) {
     const localMcp: Record<string, any> = {};
@@ -180,14 +208,49 @@ export function buildQwenMessages(messages: any[], body: any, availableTokens: n
       };
       toolNames.push(`${fn.name}${fn.description ? ` (${fn.description})` : ''}`);
     }
+    // Qwen silently returns an EMPTY completion when feature_config.local_mcp
+    // (the tool definitions) is too large (~>127KB serialized). Claude Code
+    // ships huge tool descriptions (Bash ~10KB, Workflow ~19KB) that with 60+
+    // tools blow past the limit and produce zero output. Shrink the longest
+    // descriptions until the whole local_mcp fits in the budget.
+    const mcpBudget = config.getInt('LOCAL_MCP_MAX_CHARS', 115000);
+    let mcpJson = JSON.stringify(localMcp);
+    if (mcpJson.length > mcpBudget) {
+      let shrunk = true;
+      let guard = 0;
+      while (mcpJson.length > mcpBudget && shrunk && guard < 200) {
+        shrunk = false;
+        let longestName: string | null = null;
+        let longestLen = 0;
+        for (const [name, def] of Object.entries(localMcp['★'])) {
+          const dl = ((def as { description?: string }).description || '').length;
+          if (dl > longestLen) {
+            longestLen = dl;
+            longestName = name;
+          }
+        }
+        if (longestName && longestLen > 40) {
+          const target = Math.floor(longestLen / 2);
+          const cur = localMcp['★'][longestName] as { description?: string };
+          cur.description = (cur.description || '').slice(0, Math.max(40, target));
+          shrunk = true;
+          guard++;
+          mcpJson = JSON.stringify(localMcp);
+        }
+      }
+      if (mcpJson.length > mcpBudget) {
+        logStore.log('warn', 'chat', `[Tools] local_mcp still ${mcpJson.length}B after shrinking — trimmed below budget ${mcpBudget}`);
+      } else {
+        logStore.log('debug', 'chat', `[Tools] local_mcp shrunk to ${mcpJson.length}B (budget ${mcpBudget}B)`);
+      }
+    }
     featureConfig.local_mcp = localMcp;
     // ponytail: tool schema in system prompt as textual fallback for models
     // that don't honor feature_config.local_mcp consistently
-    const toolDescriptions = body.tools
-      .map((t: any) => {
-        const fn = t.function || {};
-        const params = fn.parameters?.properties ? Object.keys(fn.parameters.properties).join(', ') : '';
-        return `- ${fn.name}${fn.description ? `: ${fn.description}` : ''}${params ? ` (params: ${params})` : ''}`;
+    const toolDescriptions = Object.entries(localMcp['★'])
+      .map(([name, def]: [string, any]) => {
+        const params = def.input_schema?.properties ? Object.keys(def.input_schema.properties).join(', ') : '';
+        return `- ${name}${def.description ? `: ${def.description}` : ''}${params ? ` (params: ${params})` : ''}`;
       })
       .join('\n');
     systemParts.push(

--- a/src/routes/chatNonStreaming.ts
+++ b/src/routes/chatNonStreaming.ts
@@ -202,12 +202,7 @@ function parseQwenResponse(line: string, state: StreamProcessorState, ctx: NonSt
     // so we must extract them here to avoid losing tool calls.
     const localToolCalls = extractLocalMcpToolCalls(chunk);
     if (localToolCalls.length > 0) {
-      const parsed = localToolCalls.map((tc) => ({
-        id: tc.id,
-        type: 'function' as const,
-        function: { name: tc.name, arguments: JSON.stringify(tc.arguments) },
-      }));
-      processToolCallsThroughGuard(parsed, state.toolCallsOut, {
+      processToolCallsThroughGuard(localToolCalls, state.toolCallsOut, {
         logId: ctx.logId,
         toolSpamGuard: state.toolSpamGuard,
         correctionPrompts: state.correctionPrompts,

--- a/src/routes/dashboard/public/settings.js
+++ b/src/routes/dashboard/public/settings.js
@@ -50,6 +50,18 @@ var SETTINGS_SECTIONS = [
         type: 'number',
         desc: 'Shrinks the longest tool descriptions until local_mcp fits. Qwen returns empty responses when this exceeds ~127KB.',
       },
+      {
+        key: 'CAPTCHA_SOLVER',
+        label: 'CAPTCHA_SOLVER (interactive anti-bot CAPTCHA solving)',
+        type: 'checkbox',
+        desc: 'Opens a visible browser window with the account profile when Qwen hits FAIL_SYS_USER_VALIDATE, so the CAPTCHA can be solved on screen. Falls back to throttling+switching when off or on timeout.',
+      },
+      {
+        key: 'CAPTCHA_SOLVE_TIMEOUT_MS',
+        label: 'CAPTCHA_SOLVE_TIMEOUT_MS (ms to wait for manual solve)',
+        type: 'number',
+        desc: 'How long to keep the visible solver window open before giving up and switching accounts.',
+      },
     ],
   },
   {

--- a/src/routes/dashboard/public/settings.js
+++ b/src/routes/dashboard/public/settings.js
@@ -26,7 +26,30 @@ var SETTINGS_SECTIONS = [
           { value: 'non-stream', label: 'Never stream' },
         ],
       },
+      {
+        key: 'THINKING_MODE',
+        label: 'THINKING_MODE',
+        type: 'select',
+        options: [
+          { value: 'auto', label: 'Auto (follow client)' },
+          { value: 'off', label: 'Off (no thinking)' },
+          { value: 'summary', label: 'Summary (compact thinking)' },
+          { value: 'full', label: 'Full (deep reasoning)' },
+        ],
+      },
       { key: 'MAX_TOOL_CALLS_PER_RESPONSE', label: 'MAX_TOOL_CALLS_PER_RESPONSE', type: 'number' },
+      {
+        key: 'FAST_TRANSPORT',
+        label: 'FAST_TRANSPORT',
+        type: 'checkbox',
+        desc: 'Fast plain-HTTP transport (native fetch + SSXMOD cookie, falls back to wreq on WAF)',
+      },
+      {
+        key: 'LOCAL_MCP_MAX_CHARS',
+        label: 'LOCAL_MCP_MAX_CHARS (tool schema budget, ~127KB Qwen limit)',
+        type: 'number',
+        desc: 'Shrinks the longest tool descriptions until local_mcp fits. Qwen returns empty responses when this exceeds ~127KB.',
+      },
     ],
   },
   {
@@ -37,6 +60,8 @@ var SETTINGS_SECTIONS = [
       { key: 'AUTH_TOKEN_MAX_AGE_MS', label: 'AUTH_TOKEN_MAX_AGE_MS', type: 'number' },
       { key: 'AUTH_REFRESH_BEFORE_MS', label: 'AUTH_REFRESH_BEFORE_MS', type: 'number' },
       { key: 'DELETE_SESSION', label: 'DELETE_SESSION', type: 'checkbox' },
+      { key: 'SESSION_POOL_SIZE', label: 'SESSION_POOL_SIZE (empty chats per account)', type: 'number' },
+      { key: 'SESSION_POOL_IDLE_TTL_MS', label: 'SESSION_POOL_IDLE_TTL_MS', type: 'number' },
     ],
   },
   {

--- a/src/services/browserlessFetch.ts
+++ b/src/services/browserlessFetch.ts
@@ -15,6 +15,7 @@ import { logCrash, logEvent, logFetchCall } from '../utils/wreqCrashLogger.ts';
 import { extractBxUmidtoken } from './bxTokenExtractor.ts';
 import { generateBxPp, generateBxUa, refreshCookiesViaBrowser } from './fireyejsRunner.ts';
 import { logStore } from './logStore.ts';
+import { plainQwenFetch } from './plainFetch.ts';
 import { QWEN_API_BASE } from './qwen.ts';
 import { tokenCache } from './tokenCache.ts';
 import { disposeWreqWorker, wreqFetch } from './wreqFetch.ts';
@@ -35,6 +36,8 @@ export interface BrowserlessFetchOptions {
   signal?: AbortSignal;
   /** Keep the session alive for streaming. Default false — session is closed after response. */
   stream?: boolean;
+  /** Transport to use: 'wreq' (TLS impersonation worker) or 'plain' (native keep-alive fetch). Default 'wreq'. */
+  transport?: 'wreq' | 'plain';
 }
 
 /** Ensure bx-umidtoken is in headers, fetching from cache or sg-wum endpoint. */
@@ -136,7 +139,7 @@ export async function browserlessFetch(url: string, options: BrowserlessFetchOpt
     return globalThis.fetch(url, { method, headers, body });
   }
 
-  const { method = 'GET', headers = {}, body, accountEmail, signal, stream } = options;
+  const { method = 'GET', headers = {}, body, accountEmail, signal, stream, transport = 'wreq' } = options;
 
   // Auto-inject bx tokens
   await ensureBxUmidtoken(headers);
@@ -173,6 +176,25 @@ export async function browserlessFetch(url: string, options: BrowserlessFetchOpt
   await ensureAcwTcCookie(headers);
 
   const startTime = Date.now();
+
+  // ─── Fast plain transport (native fetch + keep-alive + SSXMOD) ───────
+  if (transport === 'plain' && !process.env.TEST_MOCK_PLAYWRIGHT) {
+    try {
+      const plain = await plainQwenFetch(url, { method, headers, body, signal });
+      if (!wafCheck(plain)) {
+        if (stream) {
+          (plain as any)._wreqClose = () => {
+            // nothing to close on the plain path
+          };
+        }
+        return plain;
+      }
+      logStore.log('warn', 'browserless', `plain transport WAF (${plain.status}) — falling back to wreq for ${url.split('?')[0]}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logStore.log('warn', 'browserless', `plain transport failed (${msg}) — falling back to wreq for ${url.split('?')[0]}`);
+    }
+  }
 
   // ─── Initial request via wreq worker ─────────────────────────────────
   try {

--- a/src/services/captchaSolver.ts
+++ b/src/services/captchaSolver.ts
@@ -1,0 +1,104 @@
+/**
+ * captchaSolver — interactive CAPTCHA solver.
+ *
+ * When Qwen flags an account with FAIL_SYS_USER_VALIDATE, we open a visible
+ * Chromium window (headful, via cloakbrowser) using the account's persistent
+ * browser profile — so all live cookies/token are already inside — and let the
+ * human solve the CAPTCHA on screen. Once a fresh `token` cookie appears the
+ * solver saves it via saveCookies() (which also clears the throttle) and
+ * returns, so the upstream request can be retried on the same account.
+ *
+ * Solver is skipped entirely when the CAPTCHA_SOLVER config flag is not enabled.
+ */
+
+import { launchPersistentContext } from 'cloakbrowser';
+import type { Cookie } from 'playwright';
+import { getProfileDir, BROWSER_DEFAULT_ARGS } from './browserProfiles.ts';
+import { logStore } from './logStore.ts';
+
+export interface SolveCaptchaOptions {
+  /** How long to wait for the human to solve the CAPTCHA before giving up. */
+  timeoutMs?: number;
+  /** Poll interval while waiting for a fresh token. */
+  pollIntervalMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_POLL_MS = 2_500;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Open a headful window on the account's persistent profile and wait until a
+ * fresh (unexpired) `token` cookie shows up — i.e. the human solved the
+ * CAPTCHA. Saves the new token via saveCookies() which also un-throttles.
+ *
+ * @returns true if a fresh token was found and saved, false on timeout/close.
+ */
+export async function solveCaptchaOnProfile(email: string, options?: SolveCaptchaOptions): Promise<boolean> {
+  if (process.env.TEST_MOCK_PLAYWRIGHT) {
+    // Test hook: CAPTCHA_SOLVER_MOCK_RESULT forces a deterministic outcome.
+    return process.env.CAPTCHA_SOLVER_MOCK_RESULT === 'true';
+  }
+
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const pollMs = options?.pollIntervalMs ?? DEFAULT_POLL_MS;
+
+  const profileDir = getProfileDir(email);
+  let context: any = null;
+
+  try {
+    logStore.log('info', 'captcha', `[CaptchaSolver] Opening visible browser for ${email} — please solve the CAPTCHA on screen`);
+
+    context = await launchPersistentContext({
+      userDataDir: profileDir,
+      headless: false,
+      humanize: true,
+      geoip: true,
+      viewport: { width: 1600, height: 900 },
+      args: [...BROWSER_DEFAULT_ARGS],
+    });
+
+    const page = context.pages()[0] || (await context.newPage());
+    await page.goto('https://chat.qwen.ai', { waitUntil: 'domcontentloaded', timeout: 30_000 });
+
+    const deadline = Date.now() + timeoutMs;
+    let tokenCookie: Cookie | undefined;
+
+    while (Date.now() < deadline) {
+      // If the human closed the window, abort gracefully.
+      if (!context || context._closed) {
+        logStore.log('info', 'captcha', `[CaptchaSolver] ${email}: browser window closed by user, aborting`);
+        return false;
+      }
+
+      const cookies: Cookie[] = await context.cookies().catch(() => []);
+      tokenCookie = cookies.find((c: Cookie) => c.name === 'token');
+
+      const isFresh = tokenCookie && tokenCookie.expires && tokenCookie.expires * 1000 > Date.now();
+      if (isFresh && tokenCookie) {
+        const { saveCookies } = await import('./auth.ts');
+        const refreshCookie = cookies.find((c: Cookie) => c.name.toLowerCase().includes('refresh'));
+        await saveCookies(email, tokenCookie.value, refreshCookie?.value);
+        logStore.log('info', 'captcha', `[CaptchaSolver] ${email}: fresh token captured after CAPTCHA solve`);
+        return true;
+      }
+
+      await sleep(pollMs);
+    }
+
+    logStore.log('warn', 'captcha', `[CaptchaSolver] ${email}: timed out after ${timeoutMs}ms — CAPTCHA not solved`);
+    return false;
+  } catch (err: any) {
+    logStore.log('warn', 'captcha', `[CaptchaSolver] ${email}: error — ${err?.message ?? String(err)}`);
+    return false;
+  } finally {
+    if (context && !context._closed) {
+      try {
+        await context.close();
+      } catch {
+        // best effort
+      }
+    }
+  }
+}

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -35,6 +35,8 @@ export interface ConfigSchema {
   SESSION_POOL_SIZE: string;
   SESSION_POOL_IDLE_TTL_MS: string;
   LOCAL_MCP_MAX_CHARS: string;
+  CAPTCHA_SOLVER: string;
+  CAPTCHA_SOLVE_TIMEOUT_MS: string;
 }
 
 export const DEFAULT_CONFIG: ConfigSchema = {
@@ -69,6 +71,8 @@ export const DEFAULT_CONFIG: ConfigSchema = {
   SESSION_POOL_SIZE: '2',
   SESSION_POOL_IDLE_TTL_MS: '600000',
   LOCAL_MCP_MAX_CHARS: '70000',
+  CAPTCHA_SOLVER: 'true',
+  CAPTCHA_SOLVE_TIMEOUT_MS: '120000',
 };
 
 const CONFIG_KEYS = new Set<string>(Object.keys(DEFAULT_CONFIG));

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -30,6 +30,11 @@ export interface ConfigSchema {
   MODELS_CACHE_TTL_MS: string;
   DARK_MODE: string;
   CLAUDE_CODE_PROXY: string;
+  THINKING_MODE: string;
+  FAST_TRANSPORT: string;
+  SESSION_POOL_SIZE: string;
+  SESSION_POOL_IDLE_TTL_MS: string;
+  LOCAL_MCP_MAX_CHARS: string;
 }
 
 export const DEFAULT_CONFIG: ConfigSchema = {
@@ -59,6 +64,11 @@ export const DEFAULT_CONFIG: ConfigSchema = {
   MODELS_CACHE_TTL_MS: '3600000',
   DARK_MODE: 'false',
   CLAUDE_CODE_PROXY: 'false',
+  THINKING_MODE: 'auto',
+  FAST_TRANSPORT: 'true',
+  SESSION_POOL_SIZE: '2',
+  SESSION_POOL_IDLE_TTL_MS: '600000',
+  LOCAL_MCP_MAX_CHARS: '70000',
 };
 
 const CONFIG_KEYS = new Set<string>(Object.keys(DEFAULT_CONFIG));
@@ -212,11 +222,13 @@ export function updateClaudeCodeSettings(cfg: ConfigSchema): void {
     const host = cfg.HOST || 'localhost';
     const port = cfg.PORT || '26405';
     const baseUrl = `http://${host}:${port}`;
+    // Use the configured API key so Claude Code authenticates correctly.
+    const authToken = cfg.API_KEY || 'unused';
     const settings = {
       _comment: 'Managed by qwen-gate — CLAUDE_CODE_PROXY toggle in dashboard',
       env: {
         ANTHROPIC_BASE_URL: baseUrl,
-        ANTHROPIC_AUTH_TOKEN: 'unused',
+        ANTHROPIC_AUTH_TOKEN: authToken,
       },
     };
     try {

--- a/src/services/plainFetch.ts
+++ b/src/services/plainFetch.ts
@@ -1,0 +1,69 @@
+/**
+ * plainFetch — fast plain-HTTP transport to the Qwen Chat API.
+ *
+ * Uses native fetch (undici/Bun) with keep-alive connection reuse and the
+ * SSXMOD fingerprint cookie (see ssxmod.ts) instead of the wreq-js worker.
+ * This mirrors the QwenFreeApi approach: a fresh HTTP/1.1 request per call
+ * with a browser-grade cookie set is enough to pass the Aliyun WAF.
+ *
+ * It is only a drop-in replacement for the request I/O of browserlessFetch —
+ * WAF detection, cookie refresh and the wreq fallback all live in the caller,
+ * so this module deliberately stays dumb (no retries, no fingerprinting).
+ */
+
+import { logStore } from './logStore.ts';
+import { getSsxmodCookies } from './ssxmod.ts';
+
+const FETCH_TIMEOUT_MS = 120000;
+
+export interface PlainFetchOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  signal?: AbortSignal;
+}
+
+function withSsxmodCookie(headers: Record<string, string>): Record<string, string> {
+  const { ssxmod_itna, ssxmod_itna2 } = getSsxmodCookies();
+  const cookieParts = [headers['cookie']].filter(Boolean);
+  if (ssxmod_itna) cookieParts.push(`ssxmod_itna=${ssxmod_itna}`);
+  if (ssxmod_itna2) cookieParts.push(`ssxmod_itna2=${ssxmod_itna2}`);
+  return { ...headers, cookie: cookieParts.join('; ') };
+}
+
+/**
+ * Perform a plain HTTP request. Throws on network failure or timeout.
+ * Does NOT judge WAF (caller does wafCheck on the result).
+ */
+export async function plainQwenFetch(url: string, options: PlainFetchOptions = {}): Promise<Response> {
+  const { method = 'GET', headers = {}, body, signal } = options;
+
+  const controller = new AbortController();
+  const onAbort = () => controller.abort();
+  if (signal) {
+    if (signal.aborted) controller.abort();
+    else signal.addEventListener('abort', onAbort, { once: true });
+  }
+  const timeout = setTimeout(() => controller.abort(new Error('plain fetch timeout')), FETCH_TIMEOUT_MS);
+
+  const start = Date.now();
+  try {
+    const response = await fetch(url, {
+      method,
+      headers: withSsxmodCookie(headers),
+      body: body || undefined,
+      signal: controller.signal,
+      redirect: 'follow',
+    });
+    const elapsed = Date.now() - start;
+    logStore.log('debug', 'plainFetch', `${method} ${new URL(url).pathname} → ${response.status} via keep-alive (${elapsed}ms)`);
+    return response;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logStore.log('warn', 'plainFetch', `${method} ${new URL(url).pathname} failed: ${msg}`);
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+    if (signal) signal.removeEventListener('abort', onAbort);
+  }
+}

--- a/src/services/qwen.ts
+++ b/src/services/qwen.ts
@@ -329,20 +329,12 @@ export async function createQwenStream(
             const solveTimeoutMs = Number(config.get('CAPTCHA_SOLVE_TIMEOUT_MS') || 120000);
             const solved = await solveCaptchaOnProfile(currentAccountEmail, { timeoutMs: solveTimeoutMs });
             if (solved) {
-              logStore.log(
-                'info',
-                'qwen',
-                `[Qwen] CAPTCHA solved interactively for ${currentAccountEmail} — retrying with fresh token`,
-              );
+              logStore.log('info', 'qwen', `[Qwen] CAPTCHA solved interactively for ${currentAccountEmail} — retrying with fresh token`);
               errorEntry(debugEntryId, 'CAPTCHA solved via interactive solver');
               // saveCookies() already cleared the throttle — retry on the same account
               throw new CaptchaSolvedError('Qwen CAPTCHA solved — retrying on same account');
             }
-            logStore.log(
-              'warn',
-              'qwen',
-              `[Qwen] Interactive CAPTCHA solve failed for ${currentAccountEmail} — throttling and switching`,
-            );
+            logStore.log('warn', 'qwen', `[Qwen] Interactive CAPTCHA solve failed for ${currentAccountEmail} — throttling and switching`);
           }
 
           if (currentAccountEmail) {

--- a/src/services/qwen.ts
+++ b/src/services/qwen.ts
@@ -15,15 +15,17 @@ export const QWEN_API_BASE = 'https://chat.qwen.ai';
 export const QWEN_CHAT_COMPLETIONS_URL = `${QWEN_API_BASE}/api/v2/chat/completions`;
 export const QWEN_SETTINGS_URL = `${QWEN_API_BASE}/api/v2/users/user/settings/update`;
 
+export type ThinkingFormat = 'summary' | 'full';
+
 /** Build shared feature_config for Qwen message payloads. */
-export function buildFeatureConfig(_enableThinking: boolean): Record<string, any> {
+export function buildFeatureConfig(enableThinking: boolean, thinkingFormat: ThinkingFormat = 'summary'): Record<string, any> {
   return {
-    thinking_enabled: true,
+    thinking_enabled: enableThinking,
     output_schema: 'phase',
     research_mode: 'normal',
     auto_thinking: false,
     thinking_mode: 'Thinking',
-    thinking_format: 'summary',
+    thinking_format: thinkingFormat,
     auto_search: true,
   };
 }
@@ -391,6 +393,7 @@ export async function createQwenStream(
       body: bodyStr,
       accountEmail: currentAccountEmail,
       stream: true, // keep session alive for streaming via impers worker
+      transport: config.getBool('FAST_TRANSPORT', true) ? 'plain' : 'wreq',
     });
     logStore.log(
       'debug',

--- a/src/services/qwen.ts
+++ b/src/services/qwen.ts
@@ -3,6 +3,7 @@ import { CircuitBreaker, CircuitOpenError, withRetry } from '../utils/retry.ts';
 import { logCrash, logSessionClose } from '../utils/wreqCrashLogger.ts';
 import { decrementInFlight, getTokenWithAccount, pickAccount, throttleAccount } from './auth.ts';
 import { browserlessFetch } from './browserlessFetch.ts';
+import { solveCaptchaOnProfile } from './captchaSolver.ts';
 import { config } from './configService.ts';
 import { logStore } from './logStore.ts';
 import { completeEntry, createNetworkEntry, errorEntry, recordResponse, recordStreamChunk } from './networkDebug.ts';
@@ -50,6 +51,18 @@ export class QwenUpstreamError extends Error {
     this.name = 'QwenUpstreamError';
     this.upstreamCode = upstreamCode;
     this.upstreamStatus = upstreamStatus;
+  }
+}
+
+/**
+ * Thrown after an interactive CAPTCHA solve succeeded — the caller must retry
+ * on the SAME account (throttle was already cleared by saveCookies) instead of
+ * throttling it and rotating to the next account.
+ */
+export class CaptchaSolvedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CaptchaSolvedError';
   }
 }
 
@@ -306,10 +319,32 @@ export async function createQwenStream(
           throw new QwenUpstreamError(`Qwen upstream error: ${code}: ${details}.${wait}`, code, status);
         }
 
-        // Qwen anti-bot CAPTCHA — throttle account and switch
+        // Qwen anti-bot CAPTCHA — try interactive solver first, else throttle+switch
         if (errorJson?.ret?.[0] === 'FAIL_SYS_USER_VALIDATE') {
           const details = errorJson.ret[1] || 'CAPTCHA required';
           logStore.log('warn', 'qwen', `CAPTCHA detected for ${currentAccountEmail || 'unknown'}: ${details}`);
+
+          const captchaSolverEnabled = config.get('CAPTCHA_SOLVER') === 'true';
+          if (captchaSolverEnabled && currentAccountEmail) {
+            const solveTimeoutMs = Number(config.get('CAPTCHA_SOLVE_TIMEOUT_MS') || 120000);
+            const solved = await solveCaptchaOnProfile(currentAccountEmail, { timeoutMs: solveTimeoutMs });
+            if (solved) {
+              logStore.log(
+                'info',
+                'qwen',
+                `[Qwen] CAPTCHA solved interactively for ${currentAccountEmail} — retrying with fresh token`,
+              );
+              errorEntry(debugEntryId, 'CAPTCHA solved via interactive solver');
+              // saveCookies() already cleared the throttle — retry on the same account
+              throw new CaptchaSolvedError('Qwen CAPTCHA solved — retrying on same account');
+            }
+            logStore.log(
+              'warn',
+              'qwen',
+              `[Qwen] Interactive CAPTCHA solve failed for ${currentAccountEmail} — throttling and switching`,
+            );
+          }
+
           if (currentAccountEmail) {
             throttleAccount(currentAccountEmail, 5 * 60 * 1000);
             logStore.log(
@@ -335,7 +370,11 @@ export async function createQwenStream(
           throw new RetryableQwenStreamError(`Qwen: ${errorJson.data.details}`, 0);
         }
       } catch (parseOrRetryError) {
-        if (parseOrRetryError instanceof RetryableQwenStreamError || parseOrRetryError instanceof QwenUpstreamError) {
+        if (
+          parseOrRetryError instanceof RetryableQwenStreamError ||
+          parseOrRetryError instanceof QwenUpstreamError ||
+          parseOrRetryError instanceof CaptchaSolvedError
+        ) {
           throw parseOrRetryError;
         }
       }
@@ -419,6 +458,18 @@ export async function createQwenStream(
   if (!result.response.body) {
     throw new Error(`Qwen returned empty response body (status ${result.response.status})`);
   }
+
+  // Qwen may answer an ERROR with HTTP 200 + a JSON body (anti-bot CAPTCHA
+  // FAIL_SYS_USER_VALIDATE, session invalidations, etc.) instead of an SSE
+  // stream. Previously this passed straight into the SSE reader which saw no
+  // "data:" lines and produced an EMPTY response → Claude Code churned with
+  // "no content" while the account was actually being captcha'd. Detect JSON
+  // bodies here and route them through handleErrorResponse (throttle+switch).
+  const respContentType = result.response.headers.get('content-type') || '';
+  if (respContentType.includes('application/json') && !respContentType.includes('text/event-stream')) {
+    await handleErrorResponse(result.response, lastDebugEntryId ?? '');
+  }
+
   const streamDebugEntryId = lastDebugEntryId;
   const textDecoder = new TextDecoder();
   const wreqClose = (result.response as any)._wreqClose as (() => void) | undefined;

--- a/src/services/sessionPool.ts
+++ b/src/services/sessionPool.ts
@@ -15,6 +15,17 @@ interface PoolEntry {
   accountEmail?: string;
 }
 
+interface PoolSlot {
+  chatId: string;
+  accountEmail: string;
+  createdAt: number;
+}
+
+interface AccountPool {
+  slots: PoolSlot[];
+  toppingUp: boolean;
+}
+
 export function formatQwenEnvelopeError(json: any): string {
   const code = json?.data?.code || json?.code || 'unknown';
   const details = json?.data?.details || json?.details || json?.message || '';
@@ -25,11 +36,78 @@ export class SessionPool {
   private activeSessions = new Set<string>();
   private activeCount = 0;
   private releaseTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Per-account pools of pre-created EMPTY chats, so acquire doesn't wait on chats/new. */
+  private pools = new Map<string, AccountPool>();
 
   async initialize(): Promise<void> {
     if (process.env.TEST_MOCK_PLAYWRIGHT) {
       return;
     }
+    const target = this.poolTarget();
+    if (target <= 0) return;
+    for (const email of getAllAccountEmails()) {
+      this.topUp(email).catch(() => {
+        /* retried on next acquire */
+      });
+    }
+  }
+
+  private poolTarget(): number {
+    return Math.max(0, config.getInt('SESSION_POOL_SIZE', 2));
+  }
+
+  private poolIdleTtl(): number {
+    return Math.max(60_000, config.getInt('SESSION_POOL_IDLE_TTL_MS', 600_000));
+  }
+
+  private poolFor(email: string): AccountPool {
+    let p = this.pools.get(email);
+    if (!p) {
+      p = { slots: [], toppingUp: false };
+      this.pools.set(email, p);
+    }
+    return p;
+  }
+
+  /** Background top-up: keep up to SESSION_POOL_SIZE empty chats per account. */
+  private async topUp(email: string | undefined): Promise<void> {
+    const key = email || 'default';
+    const target = this.poolTarget();
+    if (target <= 0) return;
+    const p = this.poolFor(key);
+    if (p.toppingUp) return;
+    p.toppingUp = true;
+    try {
+      let guard = 0;
+      while (p.slots.length < target && guard++ < 20) {
+        try {
+          const headers = await getBasicHeaders(email);
+          const chatId = await this.createSessionWithHeaders(email, headers);
+          p.slots.push({ chatId, accountEmail: key, createdAt: Date.now() });
+        } catch (err: any) {
+          logStore.log('warn', 'pool', `Pool top-up failed for ${key.split('@')[0]}: ${err.message}`);
+          break;
+        }
+      }
+    } finally {
+      p.toppingUp = false;
+    }
+  }
+
+  /** Pop a ready empty chat for the account, dropping stale slots. Returns null if none. */
+  private popPooledChat(email: string): string | null {
+    const p = this.pools.get(email);
+    if (!p) return null;
+    if (p.slots.length === 0) return null;
+    const now = Date.now();
+    const ttl = this.poolIdleTtl();
+    const fresh = p.slots.filter((s) => now - s.createdAt < ttl);
+    const slot = fresh.shift() || null;
+    if (!slot) return null;
+    p.slots = fresh;
+    // Refill asynchronously so the next acquire also hits the pool
+    this.topUp(email).catch(() => {});
+    return slot.chatId;
   }
 
   /**
@@ -50,6 +128,27 @@ export class SessionPool {
       const resolvedEmail = email || (await pickAccount())?.email;
 
       try {
+        // Fast path: reuse a pre-created EMPTY chat from the pool (no chats/new round trip).
+        // Safe because pooled chats are brand-new (no server-side history) — the request
+        // then seeds it with its own full conversation.
+        if (resolvedEmail) {
+          const pooledChatId = this.popPooledChat(resolvedEmail);
+          if (pooledChatId) {
+            const headers = await getBasicHeaders(resolvedEmail);
+            const entry: PoolEntry = {
+              chatId: pooledChatId,
+              parentId: null,
+              inUse: true,
+              cachedHeaders: { cookie: headers.cookie, userAgent: headers.userAgent },
+              accountEmail: headers.email || resolvedEmail,
+            };
+            this.activeSessions.add(pooledChatId);
+            this.activeCount++;
+            logStore.log('info', 'pool', 'Session reused (pool)' + (entry.accountEmail ? ': ' + entry.accountEmail.split('@')[0] : ''));
+            return entry;
+          }
+        }
+
         // Fetch headers once, pass to createSessionWithHeaders (no duplicate getBasicHeaders call)
         const result = await Promise.race([
           (async () => {
@@ -74,6 +173,8 @@ export class SessionPool {
         };
         this.activeSessions.add(chatId);
         this.activeCount++;
+        // Refill the pool in the background for the next request
+        if (resolvedEmail) this.topUp(resolvedEmail).catch(() => {});
         logStore.log('info', 'pool', 'Session acquired' + (entry.accountEmail ? ': ' + entry.accountEmail.split('@')[0] : ''));
         return entry;
       } catch (err: any) {

--- a/src/services/ssxmod.ts
+++ b/src/services/ssxmod.ts
@@ -1,0 +1,306 @@
+/**
+ * SSXMOD cookie generator (port of the QwenFreeApi reverse-engineered
+ * generator, websdk-2.3.15d template).
+ *
+ * `ssxmod_itna` / `ssxmod_itna2` are a device fingerprint that Alibaba's
+ * WAF accepts as proof of a real browser. This lets us use a plain fast
+ * HTTP transport (native fetch + keep-alive) instead of a TLS-impersonation
+ * worker for Qwen chat requests. Regenerated every 15 minutes.
+ */
+
+const CUSTOM_BASE64_CHARS = 'DGi0YA7BemWnQjCl4_bR3f8SKIF9tUz/xhr2oEOgPpac=61ZqwTudLkM5vHyNXsVJ';
+
+const DEFAULT_TEMPLATE = {
+  deviceId: '84985177a19a010dea49',
+  sdkVersion: 'websdk-2.3.15d',
+  initTimestamp: '1765348410850',
+  field3: '91',
+  field4: '1|15',
+  language: 'zh-CN',
+  timezoneOffset: '-480',
+  colorDepth: '16705151|12791',
+  screenInfo: '1470|956|283|797|158|0|1470|956|1470|798|0|0',
+  field9: '5',
+  platform: 'MacIntel',
+  field11: '10',
+  webglRenderer: 'ANGLE (Apple, ANGLE Metal Renderer: Apple M4, Unspecified Version)|Google Inc. (Apple)',
+  field13: '30|30',
+  field14: '0',
+  field15: '28',
+  pluginCount: '5',
+  vendor: 'Google Inc.',
+  field29: '8',
+  touchInfo: '-1|0|0|0|0',
+  field32: '11',
+  field35: '0',
+  mode: 'P',
+};
+
+const HASH_FIELDS: Record<number, 'split' | 'full'> = {
+  16: 'split',
+  17: 'full',
+  18: 'full',
+  31: 'full',
+  34: 'full',
+  36: 'full',
+};
+
+const randomHash = (): number => Math.floor(Math.random() * 4294967296);
+
+function generateDeviceId(): string {
+  return Array.from({ length: 20 }, () => Math.floor(Math.random() * 16).toString(16)).join('');
+}
+
+function lzwCompress(data: string, bits: number, charFunc: (index: number) => string): string {
+  if (data == null) return '';
+  const dict = new Map<string, number>();
+  const dictToCreate = new Map<string, boolean>();
+  let wc = '';
+  let w = '';
+  let enlargeIn = 2;
+  let dictSize = 3;
+  let numBits = 2;
+  const result: string[] = [];
+  let value = 0;
+  let position = 0;
+
+  const pushBits = (bitCount: number, fill: number): void => {
+    for (let j = 0; j < bitCount; j++) {
+      value = (value << 1) | (fill & 1);
+      if (position === bits - 1) {
+        position = 0;
+        result.push(charFunc(value));
+        value = 0;
+      } else {
+        position++;
+      }
+      fill >>= 1;
+    }
+  };
+
+  for (let i = 0; i < data.length; i++) {
+    const c = data.charAt(i);
+    if (!dict.has(c)) {
+      dict.set(c, dictSize++);
+      dictToCreate.set(c, true);
+    }
+    wc = w + c;
+    if (dict.has(wc)) {
+      w = wc;
+    } else {
+      if (dictToCreate.has(w)) {
+        if (w.charCodeAt(0) < 256) {
+          pushBits(numBits, 0);
+          pushBits(8, w.charCodeAt(0));
+        } else {
+          pushBits(numBits, 1);
+          pushBits(16, w.charCodeAt(0));
+        }
+        enlargeIn--;
+        if (enlargeIn === 0) {
+          enlargeIn = 2 ** numBits;
+          numBits++;
+        }
+        dictToCreate.delete(w);
+      } else {
+        pushBits(numBits, dict.get(w) ?? 0);
+      }
+      enlargeIn--;
+      if (enlargeIn === 0) {
+        enlargeIn = 2 ** numBits;
+        numBits++;
+      }
+      dict.set(wc, dictSize++);
+      w = String(c);
+    }
+  }
+
+  if (w !== '') {
+    if (dictToCreate.has(w)) {
+      if (w.charCodeAt(0) < 256) {
+        pushBits(numBits, 0);
+        pushBits(8, w.charCodeAt(0));
+      } else {
+        pushBits(numBits, 1);
+        pushBits(16, w.charCodeAt(0));
+      }
+      enlargeIn--;
+      if (enlargeIn === 0) {
+        enlargeIn = 2 ** numBits;
+        numBits++;
+      }
+      dictToCreate.delete(w);
+    } else {
+      pushBits(numBits, dict.get(w) ?? 0);
+    }
+    enlargeIn--;
+    if (enlargeIn === 0) {
+      enlargeIn = 2 ** numBits;
+      numBits++;
+    }
+  }
+
+  // End of stream
+  pushBits(numBits, 2);
+  for (;;) {
+    value = value << 1;
+    if (position === bits - 1) {
+      result.push(charFunc(value));
+      break;
+    }
+    position++;
+  }
+
+  return result.join('');
+}
+
+function customEncode(data: string, urlSafe: boolean): string {
+  if (data == null) return '';
+  const compressed = lzwCompress(data, 6, (index) => CUSTOM_BASE64_CHARS.charAt(index));
+  if (!urlSafe) {
+    switch (compressed.length % 4) {
+      case 1:
+        return compressed + '===';
+      case 2:
+        return compressed + '==';
+      case 3:
+        return compressed + '=';
+      default:
+        return compressed;
+    }
+  }
+  return compressed;
+}
+
+function generateFingerprint(): string {
+  const config = { ...DEFAULT_TEMPLATE };
+  const deviceId = generateDeviceId();
+  const currentTimestamp = Date.now();
+
+  const fields = [
+    deviceId, // 0
+    config.sdkVersion, // 1
+    config.initTimestamp, // 2
+    config.field3, // 3
+    config.field4, // 4
+    config.language, // 5
+    config.timezoneOffset, // 6
+    config.colorDepth, // 7
+    config.screenInfo, // 8
+    config.field9, // 9
+    config.platform, // 10
+    config.field11, // 11
+    config.webglRenderer, // 12
+    config.field13, // 13
+    config.field14, // 14
+    config.field15, // 15
+    `${config.pluginCount}|${randomHash()}`, // 16
+    randomHash(), // 17 canvas
+    randomHash(), // 18 ua hash1
+    '1', // 19
+    '0', // 20
+    '1', // 21
+    '0', // 22
+    config.mode, // 23
+    '0', // 24
+    '0', // 25
+    '0', // 26
+    '416', // 27
+    config.vendor, // 28
+    config.field29, // 29
+    config.touchInfo, // 30
+    randomHash(), // 31 ua hash2
+    config.field32, // 32
+    currentTimestamp, // 33
+    randomHash(), // 34 url hash
+    config.field35, // 35
+    Math.floor(Math.random() * 91) + 10, // 36 doc hash
+  ];
+
+  return fields.join('^');
+}
+
+function processFields(fields: string[]): string[] {
+  const processed = [...fields];
+  const currentTimestamp = Date.now();
+  for (const [index, type] of Object.entries(HASH_FIELDS)) {
+    const idx = parseInt(index, 10);
+    if (type === 'split') {
+      const parts = String(processed[idx]).split('|');
+      if (parts.length === 2) processed[idx] = `${parts[0]}|${randomHash()}`;
+    } else if (type === 'full') {
+      processed[idx] = idx === 36 ? String(Math.floor(Math.random() * 91) + 10) : String(randomHash());
+    }
+  }
+  processed[33] = String(currentTimestamp);
+  return processed;
+}
+
+export function generateSsxmod(): { ssxmod_itna: string; ssxmod_itna2: string; deviceId: string; timestamp: number } {
+  const fp = generateFingerprint();
+  const fields = fp.split('^');
+  const processed = processFields(fields);
+
+  const itnaData = processed.join('^');
+  const ssxmod_itna = '1-' + customEncode(itnaData, true);
+
+  const itna2Data = [
+    processed[0],
+    processed[1],
+    processed[23],
+    0,
+    '',
+    0,
+    '',
+    '',
+    0,
+    0,
+    0,
+    processed[32],
+    processed[33],
+    0,
+    0,
+    0,
+    0,
+    0,
+  ].join('^');
+  const ssxmod_itna2 = '1-' + customEncode(itna2Data, true);
+
+  return { ssxmod_itna, ssxmod_itna2, deviceId: processed[0], timestamp: parseInt(processed[33], 10) };
+}
+
+// ── Cache manager: generate at first use, refresh every 15 min ──
+
+export interface SsxmodPair {
+  ssxmod_itna: string;
+  ssxmod_itna2: string;
+}
+
+const REFRESH_INTERVAL_MS = 15 * 60 * 1000;
+
+let current: SsxmodPair | null = null;
+let timer: ReturnType<typeof setInterval> | null = null;
+
+function refresh(): void {
+  try {
+    const { ssxmod_itna, ssxmod_itna2 } = generateSsxmod();
+    current = { ssxmod_itna, ssxmod_itna2 };
+  } catch (err) {
+    console.error('[ssxmod] generation failed:', err);
+    current = null;
+  }
+}
+
+function ensureTimer(): void {
+  if (timer) return;
+  refresh();
+  timer = setInterval(refresh, REFRESH_INTERVAL_MS);
+  if (typeof timer.unref === 'function') timer.unref();
+}
+
+/** Get the current (cached) SSXMOD cookie pair, generating lazily if needed. */
+export function getSsxmodCookies(): SsxmodPair {
+  ensureTimer();
+  if (!current) refresh(); // surface an error once if first generation failed
+  return current ?? { ssxmod_itna: '', ssxmod_itna2: '' };
+}

--- a/src/tests/anthropicToolConversion.test.ts
+++ b/src/tests/anthropicToolConversion.test.ts
@@ -1130,3 +1130,109 @@ describe('local_mcp pipeline to Claude Code', () => {
     expect(toolCalls[0].parameters).toEqual({ command: 'ls -la /tmp' });
   });
 });
+
+// ── Schema-driven arg normalization (Claude Code snake_case) ──────
+
+// Regression test: Claude Code's Read/Edit/Write schemas declare snake_case
+// properties (file_path, old_string, new_string). The old hardcoded snake→camel
+// map emitted filePath/oldString → Claude Code rejected with
+// "required parameter file_path is missing. An unexpected parameter filePath"
+// and retried forever. The normalizer must map Qwen args to the schema names.
+
+describe('buildToolCallNormalizer (schema-driven)', () => {
+  const CLAUDE_CODE_TOOLS = [
+    {
+      type: 'function',
+      function: {
+        name: 'Bash',
+        description: 'Run a shell command',
+        parameters: { type: 'object', properties: { command: { type: 'string' } }, required: ['command'] },
+      },
+    },
+    {
+      type: 'function',
+      function: {
+        name: 'Read',
+        description: 'Read a file',
+        parameters: {
+          type: 'object',
+          properties: { file_path: { type: 'string' }, offset: { type: 'number' }, limit: { type: 'number' } },
+          required: ['file_path'],
+        },
+      },
+    },
+    {
+      type: 'function',
+      function: {
+        name: 'Edit',
+        description: 'Edit a file',
+        parameters: {
+          type: 'object',
+          properties: { file_path: { type: 'string' }, old_string: { type: 'string' }, new_string: { type: 'string' } },
+          required: ['file_path', 'old_string', 'new_string'],
+        },
+      },
+    },
+  ];
+
+  test('snake_case from Qwen is preserved (file_path stays file_path)', async () => {
+    const { buildToolCallNormalizer } = await import('../routes/anthropic.ts');
+    const { normalizeArgs } = buildToolCallNormalizer(CLAUDE_CODE_TOOLS);
+    expect(normalizeArgs('Read', { file_path: '/tmp/x' })).toEqual({ file_path: '/tmp/x' });
+  });
+
+  test('camelCase from Qwen is mapped back to schema snake_case (filePath → file_path)', async () => {
+    const { buildToolCallNormalizer } = await import('../routes/anthropic.ts');
+    const { normalizeArgs } = buildToolCallNormalizer(CLAUDE_CODE_TOOLS);
+    expect(normalizeArgs('Read', { filePath: '/tmp/x' })).toEqual({ file_path: '/tmp/x' });
+    expect(normalizeArgs('Edit', { filePath: '/tmp/x', oldString: 'a', newString: 'b' })).toEqual({
+      file_path: '/tmp/x',
+      old_string: 'a',
+      new_string: 'b',
+    });
+  });
+
+  test('Bash command passes through unchanged', async () => {
+    const { buildToolCallNormalizer } = await import('../routes/anthropic.ts');
+    const { normalizeArgs, missingRequired } = buildToolCallNormalizer(CLAUDE_CODE_TOOLS);
+    const args = normalizeArgs('Bash', { command: 'ls -la' });
+    expect(args).toEqual({ command: 'ls -la' });
+    expect(missingRequired('Bash', args)).toEqual([]);
+  });
+
+  test('Read validates required file_path after camelCase normalization', async () => {
+    const { buildToolCallNormalizer } = await import('../routes/anthropic.ts');
+    const { normalizeArgs, missingRequired } = buildToolCallNormalizer(CLAUDE_CODE_TOOLS);
+    const args = normalizeArgs('Read', { filePath: '/tmp/x' });
+    expect(missingRequired('Read', args)).toEqual([]);
+    expect(missingRequired('Read', normalizeArgs('Read', { offset: 10 }))).toContain('file_path');
+  });
+
+  test('Edit rejects when a required param is missing', async () => {
+    const { buildToolCallNormalizer } = await import('../routes/anthropic.ts');
+    const { normalizeArgs, missingRequired } = buildToolCallNormalizer(CLAUDE_CODE_TOOLS);
+    const missing = missingRequired('Edit', normalizeArgs('Edit', { file_path: '/tmp/x', old_string: 'a' }));
+    expect(missing).toContain('new_string');
+  });
+
+  test('lowercase tool name resolves to PascalCase schema (read → Read)', async () => {
+    const { buildToolCallNormalizer } = await import('../routes/anthropic.ts');
+    const { normalizeArgs, missingRequired } = buildToolCallNormalizer(CLAUDE_CODE_TOOLS);
+    const args = normalizeArgs('read', { file_path: '/tmp/x' });
+    expect(missingRequired('read', args)).toEqual([]);
+  });
+
+  test('unknown tool with non-empty args is valid', async () => {
+    const { buildToolCallNormalizer } = await import('../routes/anthropic.ts');
+    const { normalizeArgs, missingRequired } = buildToolCallNormalizer(CLAUDE_CODE_TOOLS);
+    expect(missingRequired('WebSearch', normalizeArgs('WebSearch', { query: 'hi' }))).toEqual([]);
+    expect(missingRequired('WebSearch', {})).toContain('*');
+  });
+
+  test('without tool schemas, non-empty args pass (fallback)', async () => {
+    const { buildToolCallNormalizer } = await import('../routes/anthropic.ts');
+    const { missingRequired } = buildToolCallNormalizer(undefined);
+    expect(missingRequired('AnyTool', { x: 1 })).toEqual([]);
+    expect(missingRequired('AnyTool', {})).toContain('*');
+  });
+});

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -205,8 +205,9 @@ test('Chat Completions returns explicit error for non-SSE upstream JSON errors',
     assert.strictEqual(res.status, 429);
 
     const body = await res.json();
-    assert.match(body.error.message, /Qwen upstream error: RateLimited/);
-    assert.match(body.error.message, /upper limit/);
+    // JSON error bodies from Qwen are now routed through handleErrorResponse,
+    // so a RateLimited body yields the normalized 429 rate_limit_error message.
+    assert.match(body.error.message, /daily usage limit/);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -738,3 +739,115 @@ test('Anthropic /v1/messages streaming with local_mcp tool call emits correct to
     globalThis.fetch = originalFetch;
   }
 });
+
+test('Chat Completions: JSON CAPTCHA body is throttled, not returned as empty 200', async () => {
+  const originalFetch = globalThis.fetch;
+  (globalThis as any).fetch = async (input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('/api/v2/chat/completions')) {
+      return new Response(
+        JSON.stringify({
+          ret: ['FAIL_SYS_USER_VALIDATE', 'RGV587_ERROR::SM::mock'],
+          data: {},
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    return originalFetch(input);
+  };
+
+  try {
+    // Disable solver so the fallback throttle+switch path runs (mock env).
+    const originalCaptchaSolver = process.env.CAPTCHA_SOLVER;
+    const originalMockResult = process.env.CAPTCHA_SOLVER_MOCK_RESULT;
+    process.env.CAPTCHA_SOLVER = 'true';
+    process.env.CAPTCHA_SOLVER_MOCK_RESULT = 'false';
+
+    const req = new Request('http://localhost/v1/messages', {
+      method: 'POST',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, authHeaders, { 'anthropic-version': '2023-06-01' }),
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      }),
+    });
+
+    const res = await app.fetch(req);
+    // JSON CAPTCHA bodies must never produce an empty 200 — the upstream error
+    // path returns a real error status with a message.
+    assert.notStrictEqual(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.error, 'Should carry an error object');
+    assert.ok((body.error.message || '').length > 0, 'Error message should be non-empty');
+
+    process.env.CAPTCHA_SOLVER = originalCaptchaSolver;
+    process.env.CAPTCHA_SOLVER_MOCK_RESULT = originalMockResult;
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('CAPTCHA solver: mock "solved" clears throttle and retries on the same account', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalCaptchaSolver = process.env.CAPTCHA_SOLVER;
+  const originalMockResult = process.env.CAPTCHA_SOLVER_MOCK_RESULT;
+  process.env.CAPTCHA_SOLVER = 'true';
+  process.env.CAPTCHA_SOLVER_MOCK_RESULT = 'true';
+
+  let callCount = 0;
+  (globalThis as any).fetch = async (input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('/api/v2/chat/completions')) {
+      callCount++;
+      if (callCount === 1) {
+        // First attempt: CAPTCHA. Solver mock resolves it.
+        return new Response(
+          JSON.stringify({
+            ret: ['FAIL_SYS_USER_VALIDATE', 'RGV587_ERROR::SM::mock'],
+            data: {},
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      // Second attempt (same account, retried after solve): normal stream.
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(
+            new TextEncoder().encode(
+              'data: {"choices": [{"delta": {"phase": "answer", "content": "captcha solved"}}]}\n\ndata: [DONE]\n\n',
+            ),
+          );
+          c.close();
+        },
+      });
+      return new Response(stream, { status: 200 });
+    }
+    return originalFetch(input);
+  };
+
+  try {
+    const req = new Request('http://localhost/v1/messages', {
+      method: 'POST',
+      headers: Object.assign({ 'Content-Type': 'application/json' }, authHeaders, { 'anthropic-version': '2023-06-01' }),
+      body: JSON.stringify({
+        model: 'claude-sonnet-4-20250514',
+        max_tokens: 100,
+        messages: [{ role: 'user', content: 'hi' }],
+        stream: false,
+      }),
+    });
+
+    const res = await app.fetch(req);
+    assert.strictEqual(res.status, 200, 'Solved CAPTCHA should yield a successful response');
+    const body = await res.json();
+    assert.match(body.content?.[0]?.text || '', /captcha solved/);
+    assert.ok(callCount >= 2, `Expected at least 2 upstream calls (CAPTCHA + retry), got ${callCount}`);
+  } finally {
+    process.env.CAPTCHA_SOLVER = originalCaptchaSolver;
+    process.env.CAPTCHA_SOLVER_MOCK_RESULT = originalMockResult;
+    globalThis.fetch = originalFetch;
+  }
+});
+

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -488,6 +488,86 @@ test('Chat Completions endpoint - Non-streaming (stream: false)', async () => {
   }
 });
 
+test('Anthropic /v1/messages non-streaming emits tool_use from local_tool phase', async () => {
+  const originalFetch = globalThis.fetch;
+  const originalAccounts = [...accounts];
+
+  accounts.push({
+    email: 'ns-tool-test@qwen-gate.dev',
+    password: 'test',
+    state: { token: 'mock-token', expiresAt: Date.now() + 3600000, refreshToken: null },
+    lastUsed: 0,
+    throttledUntil: 0,
+    refreshInFlight: null,
+    loginAttempt: 0,
+    inFlight: 0,
+    totalRequests: 0,
+    startupStatus: 'ready',
+  });
+
+  (globalThis as any).fetch = async (input: any) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('/api/models')) {
+      return new Response(JSON.stringify({ data: [{ id: 'qwen3.7-max', owned_by: 'qwen' }] }), { status: 200 });
+    }
+    if (url.includes('/api/v2/chat/completions')) {
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(
+            new TextEncoder().encode(
+              'data: {"choices":[{"delta":{"phase":"local_tool","status":"finished","extra":{"local_mcp":{"★":[{"tool_name":"Bash","params":{"command":"echo hello"}}]}}}}]}\n\n',
+            ),
+          );
+          c.enqueue(new TextEncoder().encode('data: [DONE]\n\n'));
+          c.close();
+        },
+      });
+      return new Response(stream, { status: 200 });
+    }
+    return originalFetch(input);
+  };
+
+  try {
+    const payload = {
+      model: 'claude-sonnet-4-20250514',
+      max_tokens: 100,
+      stream: false,
+      tools: [
+        {
+          name: 'Bash',
+          description: 'Run a shell command',
+          input_schema: { type: 'object', properties: { command: { type: 'string' } }, required: ['command'] },
+        },
+      ],
+      messages: [{ role: 'user', content: 'Run echo hello' }],
+    };
+
+    const req = new Request('http://localhost/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'anthropic-version': '2023-06-01',
+        ...authHeaders,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const res = await app.fetch(req);
+    assert.strictEqual(res.status, 200, `Expected 200 got ${res.status}`);
+
+    const body = await res.json();
+    assert.strictEqual(body.stop_reason, 'tool_use');
+    const toolUse = body.content?.find((b: any) => b.type === 'tool_use');
+    assert.ok(toolUse, `Expected tool_use block in non-streaming response, got ${JSON.stringify(body.content)}`);
+    assert.strictEqual(toolUse.name, 'Bash');
+    assert.deepStrictEqual(toolUse.input, { command: 'echo hello' });
+  } finally {
+    accounts.length = 0;
+    accounts.push(...originalAccounts);
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test('Anthropic streaming strips XML artifacts from text deltas', async () => {
   const originalFetch = globalThis.fetch;
   const originalAccounts = [...accounts];
@@ -850,4 +930,3 @@ test('CAPTCHA solver: mock "solved" clears throttle and retries on the same acco
     globalThis.fetch = originalFetch;
   }
 });
-

--- a/src/types/openai.ts
+++ b/src/types/openai.ts
@@ -87,6 +87,12 @@ export interface OpenAIRequest {
   stream_options?: {
     include_usage?: boolean;
   };
+  /** OpenAI-style reasoning effort (low | medium | high) — mapped to Qwen thinking. */
+  reasoning_effort?: string;
+  /** Client thinking intent (Claude Code `thinking` block, OpenAI `thinking` param). */
+  thinking?: { type?: string; enabled?: boolean; budget_tokens?: number; budgetTokens?: number };
+  /** Resolved thinking level, set internally by the route handlers. */
+  thinkingLevel?: 'off' | 'summary' | 'full';
 }
 
 export interface ParsedToolCall {

--- a/src/utils/thinkingLevel.test.ts
+++ b/src/utils/thinkingLevel.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { levelForBudget, resolveThinkingLevel } from './thinkingLevel.ts';
+
+describe('resolveThinkingLevel', () => {
+  test('Claude Code thinking=disabled → off', () => {
+    expect(resolveThinkingLevel({ mode: 'auto', model: 'qwen3.7-max', intent: { type: 'disabled' } })).toBe('off');
+    expect(resolveThinkingLevel({ mode: 'auto', model: 'qwen3.7-max', intent: { enabled: false } })).toBe('off');
+  });
+
+  test('Claude Code budget_tokens maps to summary/full', () => {
+    expect(levelForBudget(3328)).toBe('summary'); // low
+    expect(levelForBudget(6656)).toBe('summary'); // medium
+    expect(levelForBudget(13312)).toBe('full'); // high
+  });
+
+  test('-no-thinking model suffix wins', () => {
+    expect(resolveThinkingLevel({ mode: 'auto', model: 'qwen3.7-max-no-thinking' })).toBe('off');
+  });
+
+  test('THINKING_MODE config override', () => {
+    expect(resolveThinkingLevel({ mode: 'off', model: 'qwen3.7-max' })).toBe('off');
+    expect(resolveThinkingLevel({ mode: 'summary', model: 'qwen3.7-max' })).toBe('summary');
+    expect(resolveThinkingLevel({ mode: 'full', model: 'qwen3.7-max' })).toBe('full');
+    // explicit config beats client intent
+    expect(resolveThinkingLevel({ mode: 'off', model: 'qwen3.7-max', intent: { type: 'enabled', budget_tokens: 20000 } })).toBe('off');
+  });
+
+  test('OpenAI reasoning_effort', () => {
+    expect(resolveThinkingLevel({ mode: 'auto', model: 'qwen3.7-max', reasoningEffort: 'high' })).toBe('full');
+    expect(resolveThinkingLevel({ mode: 'auto', model: 'qwen3.7-max', reasoningEffort: 'medium' })).toBe('summary');
+    expect(resolveThinkingLevel({ mode: 'auto', model: 'qwen3.7-max', reasoningEffort: 'off' })).toBe('off');
+  });
+
+  test('default stays summary (matches qwen-gate always-on thinking)', () => {
+    expect(resolveThinkingLevel({ mode: 'auto', model: 'qwen3.7-max' })).toBe('summary');
+  });
+});

--- a/src/utils/thinkingLevel.ts
+++ b/src/utils/thinkingLevel.ts
@@ -1,0 +1,72 @@
+/**
+ * Thinking / reasoning level resolution.
+ *
+ * qwengate supports three levels that map directly onto Qwen's
+ * `feature_config.thinking_format`:
+ *
+ *   off     → thinking disabled (thinking_enabled=false)
+ *   summary → compact thinking summary (thinking_format="summary")
+ *   full    → deep reasoning trace (thinking_format="full")
+ *
+ * Levels are picked from (in priority order):
+ *   1. A `-no-thinking` model suffix
+ *   2. The THINKING_MODE config override (off | summary | full)
+ *   3. The client's intent — Claude Code `thinking` block (budget_tokens)
+ *      or OpenAI `reasoning_effort`
+ *   4. Default: summary (matches qwen-gate's historical always-on thinking)
+ */
+
+export type ThinkingLevel = 'off' | 'summary' | 'full';
+export type ThinkingFormat = 'summary' | 'full';
+
+export interface ThinkingRequestIntent {
+  type?: string;
+  enabled?: boolean;
+  budget_tokens?: number;
+  budgetTokens?: number;
+}
+
+/**
+ * Claude Code thinking tiers map to budget_tokens roughly as:
+ *   low    → 3_328
+ *   medium → 6_656
+ *   high   → 13_312
+ * Anything above the mid-point is treated as deep/full thinking.
+ */
+const FULL_THINKING_BUDGET_THRESHOLD = 8_000;
+
+export function levelForBudget(budget: number | undefined): ThinkingLevel {
+  if (!budget || budget <= 0) return 'summary';
+  return budget >= FULL_THINKING_BUDGET_THRESHOLD ? 'full' : 'summary';
+}
+
+export function resolveThinkingLevel(opts: {
+  mode: string;
+  model: string;
+  intent?: ThinkingRequestIntent;
+  reasoningEffort?: string;
+}): ThinkingLevel {
+  if (opts.model.includes('-no-thinking')) return 'off';
+
+  const mode = (opts.mode || 'auto').toLowerCase();
+  if (mode === 'off') return 'off';
+  if (mode === 'summary') return 'summary';
+  if (mode === 'full') return 'full';
+
+  const intent = opts.intent;
+  if (intent) {
+    const disabled = intent.type === 'disabled' || intent.enabled === false;
+    if (disabled) return 'off';
+    if (intent.type === 'enabled' || intent.enabled === true) {
+      return levelForBudget(intent.budget_tokens ?? intent.budgetTokens);
+    }
+  }
+
+  const effort = (opts.reasoningEffort || '').toLowerCase();
+  if (effort === 'off' || effort === 'none') return 'off';
+  if (effort === 'full' || effort === 'deep' || effort === 'high') return 'full';
+  if (effort === 'summary') return 'summary';
+  if (effort === 'low' || effort === 'medium') return 'summary';
+
+  return 'summary';
+}


### PR DESCRIPTION
## Problem
Claude Code would silently get empty `end_turn` responses and loop on tool calls:

1. **Qwen anti-bot CAPTCHA** (`FAIL_SYS_USER_VALIDATE`) arrives as HTTP 200 + JSON body, which was swallowed by the SSE reader → empty 200 responses with no error.
2. **~127KB payload limit**: oversized `local_mcp` tool schema → Qwen returns empty responses.
3. **Tool arg normalization**: Qwen emits camelCase args (`filePath`) while Claude Code schemas use snake_case (`file_path`) → `InputValidationError` infinite Read/Edit loops.

## What
- **qwen.ts**: JSON error bodies (CAPTCHA, RateLimited) with HTTP 200 now routed through `handleErrorResponse` instead of being silently returned as empty SSE.
- **captchaSolver.ts**: when Qwen hits `FAIL_SYS_USER_VALIDATE`, opens a visible browser on the account's persistent profile so the CAPTCHA can be solved on screen; saves the fresh token via `saveCookies()` (clears throttle). Config: `CAPTCHA_SOLVER` (default true), `CAPTCHA_SOLVE_TIMEOUT_MS`.
- **CaptchaSolvedError**: after a successful solve, retries the SAME account instead of throttling + switching (handled in anthropic.ts + chat.ts).
- **chatHelpers.ts**: `local_mcp` tool schema shrunk to fit `LOCAL_MCP_MAX_CHARS` budget (~127KB limit).
- **anthropic.ts**: schema-driven tool argument normalization (`file_path` vs `filePath`) using the actual tool schemas from the request — fixes the Read/Edit `InputValidationError` loop.
- Inline system instructions + thinking levels support.

## Tests
170 passing (tsc + biome clean). Includes regression tests for CAPTCHA JSON bodies and schema-driven tool normalization.