### PR TITLE
fix(chat): enforce RateLimited walls delivered inside HTTP 200 bodies

### DIFF
--- a/src/routes/chat.ts
+++ b/src/routes/chat.ts
@@ -1,10 +1,10 @@
 import crypto from 'node:crypto';
 import { Context } from 'hono';
-import { pickAccount, throttleAccount } from '../services/auth.ts';
+import { decrementInFlight, pickAccount, throttleAccount } from '../services/auth.ts';
 import { config } from '../services/configService.ts';
 import { logStore } from '../services/logStore.ts';
 import { modelRouter } from '../services/modelRouter.ts';
-import { RetryableQwenStreamError } from '../services/qwen.ts';
+import { QwenUpstreamError, RetryableQwenStreamError, reportRateLimitWall } from '../services/qwen.ts';
 import type { QwenFileAttachment } from '../services/qwenFileUpload.ts';
 import { uploadImageAsFile, uploadLargeTextAsFile } from '../services/qwenFileUpload.ts';
 import { sessionPool } from '../services/sessionPool.ts';
@@ -18,6 +18,7 @@ import {
   createQwenStreamWithRetry,
   getModelSpecs,
   handleImageModelFallback,
+  parseQwenErrorPayload,
 } from './chatHelpers.ts';
 import { handleNonStreamingRequest } from './chatNonStreaming.ts';
 import { handleStreamingRequest } from './chatStreaming.ts';
@@ -28,6 +29,7 @@ export {
 } from './chatHelpers.ts';
 
 const MAX_MESSAGE_SIZE = 10_000_000; // 10MB — large payloads are uploaded as files via Qwen's file API
+const MAX_MID_BODY_RETRIES = 5; // mid-body RateLimited rotations for non-streaming requests
 
 async function parseRequestBody(c: Context) {
   const rawBody = await c.req.json();
@@ -339,6 +341,37 @@ async function setupSession(messages: any[], body: OpenAIRequest, availableToken
     }
     clearTimeout(firstChunkTimer);
 
+    // ── Mid-payload RateLimited gate ─────────────────────────────────
+    // Qwen sometimes accepts the request (HTTP 200) but the body/SSE carries
+    // the daily-limit error instead of content. Nothing has reached the client
+    // yet, so apply the same native wall handling as an HTTP-level RateLimited
+    // (record + throttle via reportRateLimitWall) and rotate to another account
+    // within this retry loop. With no alternative account, fall through and let
+    // the existing per-route error handling propagate the upstream message.
+    if (!firstChunk.done && firstChunk.value) {
+      const wall = parseQwenErrorPayload(new TextDecoder().decode(firstChunk.value));
+      if (wall?.code === 'RateLimited') {
+        reportRateLimitWall(resolvedEmail, routedModel, wall.waitHours);
+        const alternative = await pickAccount(resolvedEmail);
+        if (alternative) {
+          // Reserve then release — the loop's own pickAccount(lastFailedEmail) re-picks it
+          decrementInFlight(alternative.email);
+          logStore.log('warn', 'chat', `[Chat] Mid-payload RateLimited on ${resolvedEmail} (${routedModel}) — rotating account`);
+          streamReader.cancel().catch(() => {});
+          qwenAbortController?.abort();
+          sessionPool.release(session.chatId, nextParentId, sessionHeaders, resolvedEmail, false);
+          lastFailedEmail = resolvedEmail;
+          lastError = new QwenUpstreamError(wall.message, 'RateLimited', 429);
+          continue;
+        }
+        logStore.log(
+          'warn',
+          'chat',
+          `[Chat] Mid-payload RateLimited on ${resolvedEmail} (${routedModel}) — no alternative account available`,
+        );
+      }
+    }
+
     // Reconstruct stream with the first chunk prepended, then pipe remaining data through.
     // This lets us keep the first chunk (already read) while allowing async consumption.
     stream = new ReadableStream<Uint8Array>({
@@ -446,24 +479,59 @@ export async function chatCompletions(c: Context) {
       );
     }
 
-    const { session, nextParentId, sessionHeaders, resolvedEmail, stream, qwenAbortController } = await setupSession(
-      messages,
-      body,
-      contextCheck.availableTokens!,
-      toolCalling,
-      logId,
-    );
+    // Non-streaming: the client receives nothing until the final JSON, so a
+    // RateLimited wall that surfaces mid-body (after stream start) can safely
+    // rotate to another account — the detector throttles the walled account
+    // and throws QwenUpstreamError('RateLimited'); re-run setupSession here.
+    for (let midBodyAttempt = 0; ; midBodyAttempt++) {
+      const { session, nextParentId, sessionHeaders, resolvedEmail, stream, qwenAbortController } = await setupSession(
+        messages,
+        body,
+        contextCheck.availableTokens!,
+        toolCalling,
+        logId,
+      );
 
-    const completionId = 'chatcmpl-' + crypto.randomUUID();
+      const completionId = 'chatcmpl-' + crypto.randomUUID();
 
-    if (!isStream) {
-      return handleNonStreamingRequest({
+      if (!isStream) {
+        try {
+          return await handleNonStreamingRequest({
+            c,
+            logId,
+            completionId,
+            body,
+            session,
+            stream,
+            resolvedEmail,
+            initialParentId: nextParentId,
+            sessionHeaders,
+            toolCalling,
+            cleanOutput,
+          });
+        } catch (err: any) {
+          const retryable =
+            err instanceof QwenUpstreamError && err.upstreamCode === 'RateLimited' && midBodyAttempt < MAX_MID_BODY_RETRIES - 1;
+          logStore.log(
+            'warn',
+            'chat',
+            `[Chat] Mid-body RateLimited on ${resolvedEmail} — ${retryable ? `rotating account (${midBodyAttempt + 1}/${MAX_MID_BODY_RETRIES})` : 'no rotation possible'}`,
+          );
+          if (retryable) {
+            continue;
+          }
+          throw err;
+        }
+      }
+
+      return await handleStreamingRequest({
         c,
         logId,
         completionId,
         body,
         session,
         stream,
+        qwenAbortController,
         resolvedEmail,
         initialParentId: nextParentId,
         sessionHeaders,
@@ -471,21 +539,6 @@ export async function chatCompletions(c: Context) {
         cleanOutput,
       });
     }
-
-    return await handleStreamingRequest({
-      c,
-      logId,
-      completionId,
-      body,
-      session,
-      stream,
-      qwenAbortController,
-      resolvedEmail,
-      initialParentId: nextParentId,
-      sessionHeaders,
-      toolCalling,
-      cleanOutput,
-    });
   } catch (err: any) {
     console.error(`[Chat] <<< Request failed after ${Date.now() - _requestStartTime}ms: ${err?.message || err}`);
     console.error('Error in chatCompletions:', err);

--- a/src/routes/chatHelpersCore.ts
+++ b/src/routes/chatHelpersCore.ts
@@ -217,9 +217,14 @@ setInterval(
   5 * 60 * 1000,
 ).unref();
 
-export function parseQwenErrorPayload(
-  raw: string,
-): { message: string; status: import('hono/utils/http-status').ContentfulStatusCode } | null {
+export function parseQwenErrorPayload(raw: string): {
+  message: string;
+  status: import('hono/utils/http-status').ContentfulStatusCode;
+  /** Upstream error code, e.g. RateLimited / Not_Found / UpstreamError */
+  code?: string;
+  /** Hours Qwen asked to wait (RateLimited payloads carry data.num) */
+  waitHours?: number;
+} | null {
   let text = raw.trim();
   if (!text) return null;
   // Strip SSE data: prefix if present — used when checking full buffer content
@@ -233,7 +238,7 @@ export function parseQwenErrorPayload(
       const details = payload.data?.details || payload.message || 'Qwen returned an error';
       const wait = payload.data?.num !== undefined ? ` Wait about ${payload.data.num} hour(s) before trying again.` : '';
       const status = code === 'RateLimited' ? 429 : code === 'Not_Found' ? 404 : 502;
-      return { message: `Qwen upstream error: ${code}: ${details}.${wait}`, status };
+      return { message: `Qwen upstream error: ${code}: ${details}.${wait}`, status, code, waitHours: payload.data?.num };
     }
     if (payload && payload.error) {
       const msg = typeof payload.error === 'string' ? payload.error : payload.error.message || JSON.stringify(payload.error);

--- a/src/routes/chatNonStreaming.ts
+++ b/src/routes/chatNonStreaming.ts
@@ -1,5 +1,7 @@
 import { Context } from 'hono';
+import { decrementInFlight, pickAccount } from '../services/auth.ts';
 import { logStore } from '../services/logStore.ts';
+import { QwenUpstreamError, reportRateLimitWall } from '../services/qwen.ts';
 import { sessionPool } from '../services/sessionPool.ts';
 import { detectParallelToolLoop } from '../tools/guard.ts';
 import type { Message, OpenAIRequest, ParsedToolCall } from '../types/openai.ts';
@@ -47,6 +49,10 @@ interface StreamProcessorState {
   completionTokens: number;
   promptTokens: number;
   nextParentId: string | null;
+  /** Upstream envelope error ({"success":false,...}) seen mid-body */
+  upstreamCode?: string;
+  upstreamWaitHours?: number;
+  upstreamErrorMessage?: string;
 }
 
 function buildPromptString(messages: Message[]): string {
@@ -162,6 +168,18 @@ function parseQwenResponse(line: string, state: StreamProcessorState, ctx: NonSt
   if (chunk.error) {
     const errMsg = typeof chunk.error === 'string' ? chunk.error : chunk.error.message || JSON.stringify(chunk.error);
     logStore.addError(ctx.logId, `Qwen upstream SSE error: ${errMsg}`);
+    return;
+  }
+  // Qwen envelope errors arrive as {"success":false,data:{code,details,num}}
+  // — notably RateLimited walls delivered inside an HTTP 200 response body.
+  if (chunk?.success === false) {
+    const code = chunk.data?.code || chunk.code || 'UpstreamError';
+    const details = chunk.data?.details || chunk.message || 'Qwen returned an error';
+    const wait = chunk.data?.num !== undefined ? ` Wait about ${chunk.data.num} hour(s) before trying again.` : '';
+    state.upstreamCode = code;
+    state.upstreamWaitHours = chunk.data?.num;
+    state.upstreamErrorMessage = `Qwen upstream error: ${code}: ${details}.${wait}`;
+    logStore.addError(ctx.logId, state.upstreamErrorMessage);
     return;
   }
   const deltaStatus = chunk.choices?.[0]?.delta?.status;
@@ -352,11 +370,30 @@ function buildResponseFromState(state: StreamProcessorState, ctx: NonStreamingCo
 async function processContentChunks(state: StreamProcessorState, ctx: NonStreamingContext): Promise<Response> {
   const { c, logId } = ctx;
 
-  const upstreamError = parseQwenErrorPayload(state.buffer);
-  if (upstreamError) {
+  const parsedError = parseQwenErrorPayload(state.buffer);
+  const errorCode = parsedError?.code ?? state.upstreamCode;
+  if (errorCode === 'RateLimited') {
+    // RateLimited wall inside an HTTP 200 body: apply the same native cooldown
+    // as an HTTP-level wall. The client has received NOTHING yet (non-streaming),
+    // so rotating is safe — throw and let chat.ts re-run setupSession with the
+    // next account. Without an alternative account, keep the legacy behavior.
+    reportRateLimitWall(ctx.resolvedEmail, ctx.body.model, parsedError?.waitHours ?? state.upstreamWaitHours);
+    const alternative = await pickAccount(ctx.resolvedEmail);
+    if (alternative) {
+      decrementInFlight(alternative.email);
+      logStore.log('warn', 'chat', `[Chat] Mid-body RateLimited on ${ctx.resolvedEmail} — rotating account`);
+      throw new QwenUpstreamError(
+        parsedError?.message ?? state.upstreamErrorMessage ?? 'Qwen upstream error: RateLimited',
+        'RateLimited',
+        429,
+      );
+    }
+    logStore.log('warn', 'chat', `[Chat] Mid-body RateLimited on ${ctx.resolvedEmail} — no alternative account available`);
+  }
+  if (parsedError) {
     logStore.finalizeRequest(logId);
-    const cleanMessage = cleanTextOfXmlArtifacts(upstreamError.message).cleanedText || upstreamError.message;
-    return c.json({ error: { message: cleanMessage } }, upstreamError.status);
+    const cleanMessage = cleanTextOfXmlArtifacts(parsedError.message).cleanedText || parsedError.message;
+    return c.json({ error: { message: cleanMessage } }, parsedError.status);
   }
 
   flushAndDetectLoops(state, logId);

--- a/src/routes/chatStreamingHelpers.ts
+++ b/src/routes/chatStreamingHelpers.ts
@@ -92,6 +92,10 @@ export interface StreamProcessingState {
    *  rate limit, etc.). The post-stream handler flushes partial content first,
    *  then surfaces this to the client instead of dropping what was received. */
   upstreamError?: string;
+  /** Upstream error code (e.g. RateLimited) captured with upstreamError */
+  upstreamCode?: string;
+  /** Hours Qwen asked to wait — carried by RateLimited payloads (data.num) */
+  upstreamWaitHours?: number;
   /** Depth tracking for nested tool call XML blocks. >0 means suppress content emission. */
   toolCallDepth: number;
   /**
@@ -179,6 +183,22 @@ export async function processStreamData(data: any, state: StreamProcessingState,
     // content already received, THEN surface the error to the client —
     // instead of dropping everything and showing a bare server error.
     state.upstreamError = `Qwen upstream error: ${errMsg}`;
+    return 'break_stream';
+  }
+  // Qwen envelope errors arrive as {"success":false,data:{code,details,num}}
+  // — notably RateLimited walls delivered inside an HTTP 200 SSE stream.
+  if (data?.success === false) {
+    const code = data.data?.code || data.code || 'UpstreamError';
+    const details = data.data?.details || data.message || 'Qwen returned an error';
+    const wait = data.data?.num !== undefined ? ` Wait about ${data.data.num} hour(s) before trying again.` : '';
+    state.upstreamError = `Qwen upstream error: ${code}: ${details}.${wait}`;
+    state.upstreamCode = code;
+    state.upstreamWaitHours = data.data?.num;
+    logStore.addError(logId, state.upstreamError);
+    logStore.updateEntry(logId, (entry) => {
+      entry.finalResponse = entry.finalResponse || { finishReason: '', toolCallCount: 0, contentPreview: '' };
+      entry.finalResponse.finishReason = 'error';
+    });
     return 'break_stream';
   }
   const deltaStatus = data.choices?.[0]?.delta?.status;

--- a/src/routes/streamLoop.ts
+++ b/src/routes/streamLoop.ts
@@ -1,5 +1,6 @@
 import { config } from '../services/configService.ts';
 import { logStore } from '../services/logStore.ts';
+import { reportRateLimitWall } from '../services/qwen.ts';
 import { cleanTextOfXmlArtifacts, parseXmlToolCalls } from '../tools/xmlToolParser.ts';
 import { type AmplificationGuardState, checkAmplificationGuard, getSnapshotDelta, parseQwenErrorPayload } from './chatHelpers.ts';
 import { filterContentPipeline, processStreamData, type StreamProcessingCtx, type StreamProcessingState } from './chatStreamingHelpers.ts';
@@ -210,9 +211,19 @@ export async function handlePostStreamCompletion(
     }
 
     // ── Upstream error: emit it AFTER the partial content ────────────
-    const upstreamError =
-      parseQwenErrorPayload(buffer) || (streamState.upstreamError ? { message: streamState.upstreamError, status: 502 as const } : null);
+    const parsedError = parseQwenErrorPayload(buffer);
+    const upstreamCode = parsedError?.code ?? streamState.upstreamCode;
+    const upstreamWaitHours = parsedError?.waitHours ?? streamState.upstreamWaitHours;
+    const upstreamError = parsedError || (streamState.upstreamError ? { message: streamState.upstreamError, status: 502 as const } : null);
     if (upstreamError) {
+      // RateLimited wall inside an HTTP 200 stream: apply the same native
+      // cooldown as an HTTP-level wall. Content may already be out — never
+      // restart the stream here (it would duplicate output); finish with
+      // the existing error mechanism instead.
+      if (upstreamCode === 'RateLimited') {
+        reportRateLimitWall(resolvedEmail, model, upstreamWaitHours);
+        logStore.log('warn', 'chat', `[Chat] Mid-payload RateLimited on ${resolvedEmail} (${model}) — throttled, finishing stream`);
+      }
       try {
         require('fs').writeFileSync('/tmp/qwen-error-buffer.json', buffer.slice(0, 10000));
       } catch {}

--- a/src/services/qwen.ts
+++ b/src/services/qwen.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import { CircuitBreaker, CircuitOpenError, withRetry } from '../utils/retry.ts';
 import { logCrash, logSessionClose } from '../utils/wreqCrashLogger.ts';
-import { decrementInFlight, getTokenWithAccount, pickAccount, throttleAccount } from './auth.ts';
+import { decrementInFlight, getAccountByEmail, getTokenWithAccount, pickAccount, throttleAccount } from './auth.ts';
 import { browserlessFetch } from './browserlessFetch.ts';
 import { config } from './configService.ts';
 import { logStore } from './logStore.ts';
@@ -50,6 +50,24 @@ export class QwenUpstreamError extends Error {
     this.upstreamCode = upstreamCode;
     this.upstreamStatus = upstreamStatus;
   }
+}
+
+/**
+ * Native RateLimited wall enforcement — the single place that records a wall
+ * hit and applies the standard cooldown. Used by every detection path:
+ * HTTP-level error responses AND mid-payload walls (HTTP 200 body/SSE).
+ * No-op for unknown accounts (e.g. anonymous test sessions).
+ */
+export function reportRateLimitWall(
+  accountEmail: string | null | undefined,
+  model: string | null | undefined,
+  waitHours: number | null | undefined,
+): void {
+  if (!accountEmail || !getAccountByEmail(accountEmail)) return;
+  const hours = Math.max(1, Math.floor(waitHours || 1));
+  recordRateLimited(accountEmail, model || 'unknown', hours);
+  // Full Qwen-reported duration (e.g. 4h/7h) — same policy as an HTTP-level wall
+  throttleAccount(accountEmail, hours * 3600_000);
 }
 
 class UpstreamStatusError extends Error {
@@ -286,14 +304,9 @@ export async function createQwenStream(
           const code = errorJson.data?.code || errorJson.code || 'UpstreamError';
           const details = errorJson.data?.details || errorJson.message || 'Qwen returned an error';
           const wait = errorJson.data?.num !== undefined ? ` Wait about ${errorJson.data.num} hour(s) before trying again.` : '';
-          if (code === 'RateLimited' && currentAccountEmail) {
-            const waitHours = errorJson.data?.num || 1;
-            const throttleMs = waitHours * 3600_000;
+          if (code === 'RateLimited') {
             // Record the wall hit — this is the only quota signal Qwen exposes for flagship models
-            recordRateLimited(currentAccountEmail, model, waitHours);
-            // Use the full duration from Qwen (e.g. 7 hours) — do NOT cap at 2h.
-            // Capping caused accounts to become "available" while Qwen still rejected them.
-            throttleAccount(currentAccountEmail, throttleMs);
+            reportRateLimitWall(currentAccountEmail, model, errorJson.data?.num);
             const nextAccount = await pickAccount(currentAccountEmail);
             if (nextAccount) {
               currentAccountEmail = nextAccount.email;

--- a/src/tests/rateLimitedMidPayload.test.ts
+++ b/src/tests/rateLimitedMidPayload.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Deterministic regression tests for mid-payload RateLimited walls
+ * (upstream HTTP 200 carrying {"success":false,data:{code:"RateLimited"}}).
+ *
+ * TEST1  non-streaming: wall on account A → rotate → account B answers
+ * TEST2  non-streaming variant with SSE-framed wall body
+ * TEST3  streaming: wall BEFORE useful content → retry on account B
+ * TEST4  streaming: wall AFTER useful content → NO silent retry/duplicate,
+ *        walled account gets throttled, stream finishes with the error
+ */
+process.env.TEST_MOCK_PLAYWRIGHT = 'true';
+process.env.API_KEY = 'test-key-for-testing';
+
+import { afterAll, afterEach, describe, expect, mock, test } from 'bun:test';
+
+// Keep usage accounting off-disk during these tests (production .qwen/usage.json
+// must stay untouched) while still being able to assert wall recordings.
+const rateLimitedCalls: Array<[string, string | undefined, number | null | undefined]> = [];
+mock.module('../services/usageTracker.ts', () => ({
+  dayKeyFor: () => '',
+  loadUsageStore: () => {},
+  recordUsage: () => {},
+  recordRateLimited: (email: string, model: string, waitHours: number) => {
+    rateLimitedCalls.push([email, model, waitHours]);
+  },
+  pruneUsage: () => {},
+  getUsage: () => ({}),
+  getUsageSummary: () => ({ accounts: {}, days: [] }),
+}));
+
+const { app } = await import('../index.tsx');
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { accounts, rebuildEmailIndex } from '../services/accountManager.ts';
+import { sessionPool } from '../services/sessionPool.ts';
+import type { AccountEntry } from '../types/auth.ts';
+import { projectPath } from '../utils/paths.ts';
+
+// throttleAccount persists to .qwen/accounts.json — snapshot and restore the
+// production file around every test so the suite never mutates live state.
+const ACCOUNTS_FILE = projectPath('.qwen', 'accounts.json');
+const accountsFileSnapshot = readFileSync(ACCOUNTS_FILE, 'utf-8');
+
+const ACCOUNT_A = 'wall-a@test.dev';
+const ACCOUNT_B = 'wall-b@test.dev';
+
+const RATE_LIMITED_JSON = JSON.stringify({
+  success: false,
+  request_id: 'probe-req',
+  data: {
+    code: 'RateLimited',
+    details: "You've reached the upper limit for today's usage.",
+    template: 'You have reached the daily usage limit. Please wait {{num}} hours before trying again.',
+    num: 4,
+  },
+});
+
+function sse(lines: string[]): Response {
+  const body = lines.map((l) => `data: ${l}\n\n`).join('');
+  const stream = new ReadableStream({
+    start(c) {
+      c.enqueue(new TextEncoder().encode(body));
+      c.close();
+    },
+  });
+  return new Response(stream, { status: 200 });
+}
+
+function validAnswerSse(text: string): Response {
+  return sse([
+    JSON.stringify({ choices: [{ delta: { phase: 'answer', content: text } }] }),
+    JSON.stringify({ choices: [{ delta: { phase: 'finished', status: 'finished' } }] }),
+  ]);
+}
+
+const wallResponse = (): Response => new Response(RATE_LIMITED_JSON, { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+function seedAccounts(): void {
+  for (const email of [ACCOUNT_A, ACCOUNT_B]) {
+    accounts.push({
+      email,
+      password: 'test',
+      state: { token: 'mock-token', expiresAt: Date.now() + 3600000, refreshToken: null },
+      lastUsed: 0,
+      throttledUntil: 0,
+      refreshInFlight: null,
+      loginAttempt: 0,
+      inFlight: 0,
+      totalRequests: 0,
+      startupStatus: 'ready',
+    } as unknown as AccountEntry);
+  }
+  rebuildEmailIndex(); // getAccountByEmail/throttleAccount resolve via the email index
+}
+
+function resetState(): void {
+  accounts.length = 0;
+  rateLimitedCalls.length = 0;
+}
+
+// Deterministic account selection: sessionPool.acquire passes the picked email
+// through even in TEST_MOCK_PLAYWRIGHT mode (which otherwise hardcodes mock@test).
+const originalAcquire = sessionPool.acquire;
+let chatSeq = 0;
+(sessionPool as any).acquire = async (email?: string) => ({
+  chatId: `wall-test-chat-${++chatSeq}`,
+  parentId: null,
+  inUse: true,
+  accountEmail: email,
+});
+
+afterEach(() => {
+  writeFileSync(ACCOUNTS_FILE, accountsFileSnapshot);
+});
+
+afterAll(() => {
+  (sessionPool as any).acquire = originalAcquire;
+  accounts.length = 0;
+  writeFileSync(ACCOUNTS_FILE, accountsFileSnapshot);
+});
+
+async function postChat(payload: Record<string, unknown>): Promise<{ res: Response; bodyText: string }> {
+  const req = new Request('http://localhost/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-key-for-testing' },
+    body: JSON.stringify({ model: 'qwen3.6-plus', messages: [{ role: 'user', content: 'hello' }], ...payload }),
+  });
+  const res = await app.fetch(req);
+  const bodyText = await res.text();
+  return { res, bodyText };
+}
+
+function accountByEmail(email: string): AccountEntry {
+  return accounts.find((a) => a.email === email)!;
+}
+
+describe('mid-payload RateLimited walls (HTTP 200)', () => {
+  test('TEST1: non-streaming JSON wall on A → B serves, A throttled', async () => {
+    resetState();
+    seedAccounts();
+
+    const originalFetch = globalThis.fetch;
+    let chatCalls = 0;
+    (globalThis as any).fetch = async (input: any) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('/api/models')) {
+        return new Response(JSON.stringify({ data: [{ id: 'qwen3.6-plus', owned_by: 'qwen' }] }), { status: 200 });
+      }
+      if (url.includes('/api/v2/chat/completions')) {
+        chatCalls++;
+        return chatCalls === 1 ? wallResponse() : validAnswerSse('Hello from account B');
+      }
+      return originalFetch(input);
+    };
+
+    try {
+      const { res, bodyText } = await postChat({ stream: false });
+      expect(res.status).toBe(200);
+      const body = JSON.parse(bodyText);
+      expect(body.object).toBe('chat.completion');
+      expect(body.choices[0].message.content).toBe('Hello from account B');
+
+      expect(chatCalls).toBe(2);
+      expect(accountByEmail(ACCOUNT_A).throttledUntil).toBeGreaterThan(Date.now());
+      // Native accounting recorded the wall with Qwen's reported wait hours
+      expect(rateLimitedCalls.some(([email, , hours]) => email === ACCOUNT_A && (hours ?? 0) >= 4)).toBe(true);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('TEST2: non-streaming SSE-framed wall on A → B serves, A throttled', async () => {
+    resetState();
+    seedAccounts();
+
+    const originalFetch = globalThis.fetch;
+    let chatCalls = 0;
+    (globalThis as any).fetch = async (input: any) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('/api/models')) {
+        return new Response(JSON.stringify({ data: [{ id: 'qwen3.6-plus', owned_by: 'qwen' }] }), { status: 200 });
+      }
+      if (url.includes('/api/v2/chat/completions')) {
+        chatCalls++;
+        if (chatCalls === 1) {
+          // Wall framed as an SSE data line instead of a bare JSON body
+          return sse([
+            JSON.stringify({
+              success: false,
+              data: { code: 'RateLimited', details: "You've reached the upper limit for today's usage.", num: 4 },
+            }),
+          ]);
+        }
+        return validAnswerSse('Recovered on account B');
+      }
+      return originalFetch(input);
+    };
+
+    try {
+      const { res, bodyText } = await postChat({ stream: false });
+      expect(res.status).toBe(200);
+      const body = JSON.parse(bodyText);
+      expect(body.choices[0].message.content).toBe('Recovered on account B');
+      expect(chatCalls).toBe(2);
+      expect(accountByEmail(ACCOUNT_A).throttledUntil).toBeGreaterThan(Date.now());
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('TEST3: streaming wall before useful content → retried on B, valid stream served', async () => {
+    resetState();
+    seedAccounts();
+
+    const originalFetch = globalThis.fetch;
+    let chatCalls = 0;
+    (globalThis as any).fetch = async (input: any) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('/api/models')) {
+        return new Response(JSON.stringify({ data: [{ id: 'qwen3.6-plus', owned_by: 'qwen' }] }), { status: 200 });
+      }
+      if (url.includes('/api/v2/chat/completions')) {
+        chatCalls++;
+        return chatCalls === 1 ? wallResponse() : validAnswerSse('Streamed after rotation');
+      }
+      return originalFetch(input);
+    };
+
+    try {
+      const { res, bodyText } = await postChat({ stream: true });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Content-Type')).toContain('text/event-stream');
+
+      expect(bodyText).toContain('Streamed after rotation');
+      expect(bodyText).not.toContain('RateLimited'); // wall never leaked to the client
+      expect(bodyText.split('"role":"assistant"').length - 1).toBeLessThanOrEqual(1); // no restarted stream
+
+      expect(chatCalls).toBe(2);
+      expect(accountByEmail(ACCOUNT_A).throttledUntil).toBeGreaterThan(Date.now());
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test('TEST4: streaming wall AFTER content → no duplicate output, account throttled', async () => {
+    resetState();
+    seedAccounts();
+
+    const originalFetch = globalThis.fetch;
+    let chatCalls = 0;
+    (globalThis as any).fetch = async (input: any) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('/api/models')) {
+        return new Response(JSON.stringify({ data: [{ id: 'qwen3.6-plus', owned_by: 'qwen' }] }), { status: 200 });
+      }
+      if (url.includes('/api/v2/chat/completions')) {
+        chatCalls++;
+        if (chatCalls === 1) {
+          // Useful content first, THEN the wall — nothing usable to rotate into
+          // a clean restart once deltas were already emitted.
+          const stream = new ReadableStream({
+            start(c) {
+              c.enqueue(
+                new TextEncoder().encode(
+                  `data: ${JSON.stringify({ choices: [{ delta: { phase: 'answer', content: 'Partial useful answer' } }] })}\n\n`,
+                ),
+              );
+              c.enqueue(
+                new TextEncoder().encode(
+                  `data: ${JSON.stringify({
+                    success: false,
+                    data: { code: 'RateLimited', details: "You've reached the upper limit for today's usage.", num: 4 },
+                  })}\n\n`,
+                ),
+              );
+              c.close();
+            },
+          });
+          return new Response(stream, { status: 200 });
+        }
+        return validAnswerSse('SHOULD NOT BE SERVED');
+      }
+      return originalFetch(input);
+    };
+
+    try {
+      const { res, bodyText } = await postChat({ stream: true });
+      expect(res.status).toBe(200);
+
+      // Partial content preserved exactly once, no silent restart/duplication
+      expect(bodyText.split('Partial useful answer').length - 1).toBe(1);
+      expect(bodyText).not.toContain('SHOULD NOT BE SERVED');
+      // Error surfaced through the existing mechanism, stream terminated
+      expect(bodyText).toContain('RateLimited');
+      expect(bodyText).toContain('[DONE]');
+
+      expect(chatCalls).toBe(1); // no retry after output was emitted
+      expect(accountByEmail(ACCOUNT_A).throttledUntil).toBeGreaterThan(Date.now());
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
Qwen can accept a request (HTTP 200) and return the daily-limit error
inside the JSON body or SSE stream. Those paths (parseQwenErrorPayload /
per-chunk detection) never recorded the wall nor throttled the account,
so the exhausted account kept being re-picked.

- extract native wall handling into reportRateLimitWall() (qwen.ts) and
  reuse it from the HTTP-level error path and every mid-payload path
- chat.ts: first-chunk gate — record+throttle and rotate accounts while
  nothing has reached the client (streaming and non-streaming)
- chat.ts: non-streaming mid-body walls rotate by re-running setupSession
  (client has received nothing until the final JSON)
- streamLoop.ts: post-stream walls apply the same cooldown and finish via
  the existing error mechanism — no silent restart, no duplicated output
- chatStreamingHelpers/chatNonStreaming: detect {success:false} envelope
  payloads mid-stream/mid-body and carry code + waitHours
- tests: deterministic TEST1-TEST4 covering rotation before output and
  throttle-only after output
